### PR TITLE
Send DSS_FAKE_504_PROBABILITY as a header.

### DIFF
--- a/test/test_dss_api_retry.py
+++ b/test/test_dss_api_retry.py
@@ -69,7 +69,7 @@ class TestDssApiRetry(unittest.TestCase):
                 replica="aws",
             ),
             headers={
-                'Cookie': "DSS_FAKE_504_PROBABILITY=0.5",
+                'DSS_FAKE_504_PROBABILITY': "0.5",
             },
         )
 


### PR DESCRIPTION
After https://github.com/HumanCellAtlas/data-store/pull/840, the probability comes in as a header, not as a cookie.