### PR TITLE
upload: fix list command to work for areas with many files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,13 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  argument-count:
+    enabled: false
+  method-complexity:
+    config:
+      threshold: 6
+exclude_patterns:
+  - "build/"
+  - "dist/"
+  - "scripts/"
+  - "test/"
+  - "hca/dss/"

--- a/hca/upload/__init__.py
+++ b/hca/upload/__init__.py
@@ -34,18 +34,20 @@ def forget_area(uuid_or_alias):
         raise UploadException("\"%s\" matches more than one area, please provide more characters." % (uuid_or_alias,))
 
 
-def list_current_area():
+def list_current_area(detail=False):
     """
-    Returns array of dicts describing the files in the currently selected Upload Area.
+    A generator that returns dicts describing the files in the currently selected Upload Area.
     """
-    return list_area(UploadConfig().current_area)
+    for file_info in UploadArea(uuid=UploadConfig().current_area).list(detail=detail):
+        yield file_info
 
 
-def list_area(area_uuid):
+def list_area(area_uuid, detail=False):
     """
-    Returns array of dicts describing the files in the Upload Area with the supplied UUID.
+    A generator that returns dicts describing the files in the Upload Area with the supplied UUID.
     """
-    return UploadArea(uuid=area_uuid).list()
+    for file_info in UploadArea(uuid=area_uuid).list(detail=detail):
+        yield file_info
 
 
 def list_areas():

--- a/hca/upload/api_client.py
+++ b/hca/upload/api_client.py
@@ -14,7 +14,9 @@ class ApiClient:
         url = "{api_url_base}/area/{uuid}/files_info".format(api_url_base=self.api_url_base, uuid=area_uuid)
         response = requests.put(url, data=(json.dumps(file_list)))
         if not response.ok:
-            raise RuntimeError("GET {url} returned {status}, {content}".format(url=url,
-                                                                               status=response.status_code,
-                                                                               content=response.content))
+            raise RuntimeError(
+                "GET {url} returned {status}, {content}".format(
+                    url=url,
+                    status=response.status_code,
+                    content=response.content))
         return response.json()

--- a/hca/upload/api_client.py
+++ b/hca/upload/api_client.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 
 
@@ -8,8 +10,11 @@ class ApiClient:
     def __init__(self, deployment_stage):
         self.api_url_base = ApiClient.UPLOAD_SERVICE_API_URL_TEMPLATE.format(deployment_stage=deployment_stage)
 
-    def list_area(self, area_uuid):
-        url = "{api_url_base}/area/{uuid}".format(api_url_base=self.api_url_base, uuid=area_uuid)
-        response = requests.get(url)
-        assert response.ok
-        return response.json()['files']
+    def files_info(self, area_uuid, file_list):
+        url = "{api_url_base}/area/{uuid}/files_info".format(api_url_base=self.api_url_base, uuid=area_uuid)
+        response = requests.put(url, data=(json.dumps(file_list)))
+        if not response.ok:
+            raise RuntimeError("GET {url} returned {status}, {content}".format(url=url,
+                                                                               status=response.status_code,
+                                                                               content=response.content))
+        return response.json()

--- a/hca/upload/cli/list_area_command.py
+++ b/hca/upload/cli/list_area_command.py
@@ -14,8 +14,7 @@ class ListAreaCommand(UploadCLICommand):
         list_area_parser.add_argument('-l', '--long', action='store_true', help="Long listing - show file details.")
 
     def __init__(self, args):
-        files = list_current_area()
-        for f in files:
+        for f in list_current_area(detail=args.long):
             print(f['name'])
             if args.long:
                 print("\t%-12s %d bytes\n\t%-12s %s\n\t%-12s %s" % (

--- a/hca/upload/s3_agent.py
+++ b/hca/upload/s3_agent.py
@@ -53,6 +53,12 @@ class S3Agent:
             self.cumulative_bytes_transferred = 0
             obj.upload_fileobj(fh, **upload_fileobj_args)
 
+    def list_bucket_by_page(self, bucket_name, key_prefix):
+        paginator = self.s3.meta.client.get_paginator('list_objects')
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=key_prefix, PaginationConfig={'PageSize': 100}):
+            if 'Contents' in page:
+                yield [o['Key'] for o in page['Contents']]
+
     @classmethod
     def transfer_config(cls, file_size):
         etag_stride = cls._s3_chunk_size(file_size)

--- a/hca/upload/upload_area_urn.py
+++ b/hca/upload/upload_area_urn.py
@@ -21,6 +21,9 @@ class UploadAreaURN:
         else:
             raise UploadException("Bad URN: %s" % (urn,))
 
+    def __repr__(self):
+        return ":".join(['dcp', 'upl', 'aws', self.deployment_stage, self.uuid])
+
     @property
     def credentials(self):
         uppercase_credentials = json.loads(base64.b64decode(self.encoded_credentials).decode('ascii'))

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -4,6 +4,8 @@ import unittest
 from argparse import Namespace
 
 import requests_mock
+import boto3
+from moto import mock_s3
 
 from ... import CapturingIO, reset_tweak_changes
 from .. import mock_current_upload_area
@@ -16,38 +18,49 @@ from hca.upload.cli.list_area_command import ListAreaCommand
 
 class TestUploadListAreaCommand(unittest.TestCase):
 
+    def setUp(self):
+        self.s3_mock = mock_s3()
+        self.s3_mock.start()
+
+        self.deployment_stage = 'test'
+        self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
+        self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
+        self.upload_bucket.create()
+
+    def tearDown(self):
+        self.s3_mock.stop()
+
     @reset_tweak_changes
     def test_list_area_command(self):
-
         area = mock_current_upload_area()
+        self.upload_bucket.Object('/'.join([area.uuid, 'file1.fastq.gz'])).put(Body="foo")
+        self.upload_bucket.Object('/'.join([area.uuid, 'sample.json'])).put(Body="foo")
 
-        with requests_mock.mock() as m:
-            mock_url = 'https://upload.test.data.humancellatlas.org/v1/area/{uuid}'.format(uuid=area.uuid)
-            m.get(mock_url, text='{"files":[{"name":"file1.fastq.gz"},{"name":"sample.json"}]}')
-
-            with CapturingIO('stdout') as stdout:
-                ListAreaCommand(Namespace(long=False))
+        with CapturingIO('stdout') as stdout:
+            ListAreaCommand(Namespace(long=False))
 
         self.assertEqual(stdout.captured(), "file1.fastq.gz\nsample.json\n")
 
     @reset_tweak_changes
     def test_list_area_command_with_long_option(self):
-
         area = mock_current_upload_area()
+        self.upload_bucket.Object('/'.join([area.uuid, 'file1.fastq.gz'])).put(Body="foo")
 
         with requests_mock.mock() as m:
-            mock_url = 'https://upload.test.data.humancellatlas.org/v1/area/{uuid}'.format(uuid=area.uuid)
-            m.get(mock_url, text='{"files":['
+            mock_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/files_info'.format(
+                stage=self.deployment_stage,
+                uuid=area.uuid)
+            m.put(mock_url, text='['
                                  '{"name":"file1.fastq.gz",'
-                                 '"content_type":"foo/bar",'
+                                 '"content_type":"binary/octet-stream dcp-type=data",'
                                  '"size":123,'
                                  '"url":"http://example.com",'
                                  '"checksums":{"sha1":"shaaa"}}'
-                                 ']}')
+                                 ']')
 
             with CapturingIO('stdout') as stdout:
                 ListAreaCommand(Namespace(long=True))
 
         self.assertRegexpMatches(stdout.captured(), "size\s+123")
-        self.assertRegexpMatches(stdout.captured(), "Content-Type\s+foo/bar")
+        self.assertRegexpMatches(stdout.captured(), "Content-Type\s+binary/octet-stream dcp-type=data")
         self.assertRegexpMatches(stdout.captured(), "SHA1\s+shaaa")

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -52,7 +52,7 @@ class TestUploadListAreaCommand(unittest.TestCase):
                 uuid=area.uuid)
             m.put(mock_url, text='['
                                  '{"name":"file1.fastq.gz",'
-                                 '"content_type":"binary/octet-stream dcp-type=data",'
+                                 '"content_type":"binary/octet-stream; dcp-type=data",'
                                  '"size":123,'
                                  '"url":"http://example.com",'
                                  '"checksums":{"sha1":"shaaa"}}'
@@ -62,5 +62,5 @@ class TestUploadListAreaCommand(unittest.TestCase):
                 ListAreaCommand(Namespace(long=True))
 
         self.assertRegexpMatches(stdout.captured(), "size\s+123")
-        self.assertRegexpMatches(stdout.captured(), "Content-Type\s+binary/octet-stream dcp-type=data")
+        self.assertRegexpMatches(stdout.captured(), "Content-Type\s+binary/octet-stream; dcp-type=data")
         self.assertRegexpMatches(stdout.captured(), "SHA1\s+shaaa")


### PR DESCRIPTION
Instead of getting the file list through the Upload API, get file list directly from S3.  This means regular listings are very fast and we avoid proxied pagination.

If we are doing long listings, get detail on batches of files from the Upload API, so we don't have to give users read access to files.  Batch 100 files at a time, so the UI is fairly response (and we don't blow API gateway timeouts).