### PR TITLE
Remove hardcoded HCA dependencies from upload CLI

### DIFF
--- a/hca/upload/api_client.py
+++ b/hca/upload/api_client.py
@@ -2,13 +2,13 @@ import json
 
 import requests
 
+from .upload_config import UploadConfig
+
 
 class ApiClient:
 
-    UPLOAD_SERVICE_API_URL_TEMPLATE = "https://upload.{deployment_stage}.data.humancellatlas.org/v1"
-
     def __init__(self, deployment_stage):
-        self.api_url_base = ApiClient.UPLOAD_SERVICE_API_URL_TEMPLATE.format(deployment_stage=deployment_stage)
+        self.api_url_base = UploadConfig().upload_service_api_url_template.format(deployment_stage=deployment_stage)
 
     def files_info(self, area_uuid, file_list):
         url = "{api_url_base}/area/{uuid}/files_info".format(api_url_base=self.api_url_base, uuid=area_uuid)

--- a/hca/upload/cli/__init__.py
+++ b/hca/upload/cli/__init__.py
@@ -7,7 +7,7 @@ from .common import UploadCLICommand
 
 
 def add_commands(subparsers):
-    upload_parser = subparsers.add_parser('upload', help="Upload data to HCA")
+    upload_parser = subparsers.add_parser('upload', help="Upload data to DCP")
     upload_subparsers = upload_parser.add_subparsers()
 
     help_parser = upload_subparsers.add_parser('help',

--- a/hca/upload/cli/upload_command.py
+++ b/hca/upload/cli/upload_command.py
@@ -10,7 +10,6 @@ class UploadCommand(UploadCLICommand):
     """
     Upload a file to the currently selected upload area.
     """
-    UPLOAD_BUCKET_TEMPLATE = "org-humancellatlas-upload-%s"
     COMPARISON_TOOL = "https://s3-accelerate-speedtest.s3-accelerate.amazonaws.com/en/accelerate-speed-comparsion.html"
 
     @classmethod
@@ -56,8 +55,10 @@ class UploadCommand(UploadCLICommand):
     def _load_config(self):
         self.config = UploadConfig()
         if not self.config.current_area:
-            sys.stderr.write("\nThere is not upload area selected.\n" +
-                             "Please select one with \"hca upload select <urn_or_alias>\"\n\n")
+            sys.stderr.write("\nThere is no upload area selected.\n" +
+                             "Please select one with \"{cmdname} upload select <urn_or_alias>\"\n\n".format(
+                                 cmdname=sys.argv[0]))
+            exit(1)
 
     def _check_args(self, args):
         if args.target_filename and len(args.file_paths) > 1:

--- a/hca/upload/upload_config.py
+++ b/hca/upload/upload_config.py
@@ -7,16 +7,27 @@ class UploadConfig:
     """
 
     DEFAULT_BUCKET_NAME_TEMPLATE = "org-humancellatlas-upload-{deployment_stage}"
+    DEFAULT_UPLOAD_SERVICE_API_URL_TEMPLATE = "https://upload.{deployment_stage}.data.humancellatlas.org/v1"
 
     def __init__(self):
         self._load_config()
+        self._set_defaults()
 
     def _load_config(self):
         self._config = get_config()
+
+    def _set_defaults(self):
         if 'upload' not in self._config:
             self._config.upload = {}
         if 'areas' not in self._config.upload:
             self._config.upload.areas = {}
+        if 'current_area' not in self._config.upload:
+            self._config.upload.current_area = None
+        if 'bucket_name_template' not in self._config.upload:
+            self._config.upload.bucket_name_template = self.DEFAULT_BUCKET_NAME_TEMPLATE
+        if 'upload_service_api_url_template' not in self._config.upload:
+            self._config.upload.upload_service_api_url_template = self.DEFAULT_UPLOAD_SERVICE_API_URL_TEMPLATE
+        self.save()
 
     def areas(self):
         return self._config.upload.areas
@@ -43,10 +54,11 @@ class UploadConfig:
 
     @property
     def bucket_name_template(self):
-        if 'bucket_name_template' not in self._config.upload:
-            self._config.upload.bucket_name_template = self.DEFAULT_BUCKET_NAME_TEMPLATE
-            self.save()
         return self._config.upload.bucket_name_template
+
+    @property
+    def upload_service_api_url_template(self):
+        return self._config.upload.upload_service_api_url_template
 
     def save(self):
         self._config.save()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ flake8
 moto
 coverage
 pyyaml
-requests_mock
+responses
 backports.tempfile
 mock
 -r requirements.txt

--- a/test/upload/cli/test_config.py
+++ b/test/upload/cli/test_config.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import unittest
+from argparse import Namespace
+
+import responses
+import boto3
+from moto import mock_s3
+
+from ... import CapturingIO, reset_tweak_changes
+from .. import mock_current_upload_area
+
+import hca
+
+from hca.upload.cli.list_area_command import ListAreaCommand
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.s3_mock = mock_s3()
+        self.s3_mock.start()
+
+        self.deployment_stage = 'test'
+        self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
+        self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
+        self.upload_bucket.create()
+
+        self.area = mock_current_upload_area()
+        self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
+
+    def tearDown(self):
+        self.s3_mock.stop()
+
+    @reset_tweak_changes
+    @responses.activate
+    def test_we_access_hca_url_by_default(self):
+
+        list_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/files_info'.format(
+            stage=self.deployment_stage,
+            uuid=self.area.uuid)
+        responses.add(responses.PUT, list_url, json={}, status=200)
+
+        with CapturingIO('stdout') as stdout:
+            ListAreaCommand(Namespace(long=True))
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, list_url)
+
+    @reset_tweak_changes
+    @responses.activate
+    def test_we_access_configured_upload_service_api_endpoint(self):
+        config = hca.get_config()
+        config.upload.upload_service_api_url_template = "http://upload.example.com/v1"
+        config.save()
+
+        list_url = 'http://upload.example.com/v1/area/{uuid}/files_info'.format(uuid=self.area.uuid)
+        responses.add(responses.PUT, list_url, json={}, status=200)
+
+        with CapturingIO('stdout') as stdout:
+            ListAreaCommand(Namespace(long=True))
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, list_url)


### PR DESCRIPTION
upload: make upload_service_api_url_template configurable
Also:
- Clean up default setting.
- Actually abort when there is not current_area.
- Remove a couple of references to HCA.