### PR TITLE
Retry streaming read errors in bundle download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 test: lint install
-	coverage run --source=$$(python setup.py --name) -m unittest discover
+	coverage run --source=$$(python setup.py --name) -m unittest discover -v
 
 lint:
 	./setup.py flake8

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -6,7 +6,7 @@ import uuid
 from io import open
 
 import requests
-from requests.packages.urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError, MaxRetryError
+from requests.packages.urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError
 
 from ..util import SwaggerClient
 from ..util.exceptions import SwaggerAPIException

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -6,6 +6,7 @@ import uuid
 from io import open
 
 import requests
+from requests.packages.urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError, MaxRetryError
 
 from ..util import SwaggerClient
 from ..util.exceptions import SwaggerAPIException
@@ -37,24 +38,21 @@ class DSSClient(SwaggerClient):
             file_uuid = file_["uuid"]
             filename = file_.get("name", file_uuid)
 
-            logger.info("File %s: Retrieving...", filename)
-            response = self.get_file._request(dict(uuid=file_uuid, replica=replica), stream=True)
+            logger.info("Retrieving file %s", filename)
 
+            file_path = os.path.join(dest_name, filename)
+
+            retries = self.get_session().adapters["https://"].max_retries
+            # When streaming response data, requests/urllib3 does not obey its usual retry logic, so we reenact it here.
             try:
-                if response.ok:
-                    file_path = os.path.join(dest_name, filename)
+                with self.get_file.stream(uuid=file_uuid, replica=replica) as fh, open(file_path, "wb") as dest_fh:
                     logger.info("%s", "File {}: GET SUCCEEDED. Writing to disk.".format(filename))
-                    with open(file_path, "wb") as fh:
-                        for chunk in response.iter_content(chunk_size=1024*1024):
-                            if chunk:
-                                fh.write(chunk)
+                    while True:
+                        dest_fh.write(fh.raw.read(1024*1024))
                     logger.info("%s", "File {}: GET SUCCEEDED. Stored at {}.".format(filename, file_path))
-
-                else:
-                    logger.error("%s", "File {}: GET FAILED.".format(filename))
-                    logger.error("%s", "Response: {}".format(response.text))
-            finally:
-                response.close()
+            except (ProtocolError, DecodeError, ReadTimeoutError) as e:
+                logger.error(e)
+                retries = retries.increment(method="GET", error=e)
         return {}
 
     def upload(self, src_dir, replica, staging_bucket, timeout_seconds=1200):

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -48,7 +48,10 @@ class DSSClient(SwaggerClient):
                 with self.get_file.stream(uuid=file_uuid, replica=replica) as fh, open(file_path, "wb") as dest_fh:
                     logger.info("%s", "File {}: GET SUCCEEDED. Writing to disk.".format(filename))
                     while True:
-                        dest_fh.write(fh.raw.read(1024*1024))
+                        chunk = fh.raw.read(1024*1024)
+                        if len(chunk) == 0:
+                            break
+                        dest_fh.write(chunk)
                     logger.info("%s", "File {}: GET SUCCEEDED. Stored at {}.".format(filename, file_path))
             except (ProtocolError, DecodeError, ReadTimeoutError) as e:
                 logger.error(e)


### PR DESCRIPTION
Could use some tests and also a warning in the client's streaming API autodoc, but I'm not sure how I would set up a test case, and I'd like to postpone docs until I verify that this works in the download stress tests.