### PR TITLE
Add HTTP resume to DCP CLI download.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -108,7 +108,7 @@ class RetryPolicy(retry.Retry):
 
 class _ClientMethodFactory(object):
     retry_policy = RetryPolicy(read=10, status=10, status_forcelist=frozenset({500, 502, 503, 504}))
-    timeout_policy = timeout.Timeout(connect=60, read=120)
+    timeout_policy = timeout.Timeout(connect=60, read=10)
 
     def __init__(self, client, parameters, path_parameters, http_method, method_name, method_data, body_props):
         self.__dict__.update(locals())


### PR DESCRIPTION
This allows us to do ranged gets rather than restart the entire download.

Verify the resulting download for extra correctness.

Test plan: Start a download, yank the ethernet cable, plug it back in, and watch the download succeed.