### PR TITLE
Bump pyOpenSSL dependency on Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     extras_require={
         ':python_version == "2.7"': [
             'enum34 >= 1.1.6, < 2',
-            'funcsigs >= 1.0.2, < 2'
+            'funcsigs >= 1.0.2, < 2',
+            'pyopenssl >= 17.5.0'
         ],
         ':python_version < "3.5"': ['typing >= 3.6.2, < 4'],
     },


### PR DESCRIPTION
This avoids incompatibilities with older versions of OpenSSL and errors like this:

    AttributeError: 'module' object has no attribute 'SSL_ST_INIT'