### PR TITLE
Fix the put-bundles test

### DIFF
--- a/test/test_dss_api.py
+++ b/test/test_dss_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import unittest, os, sys, filecmp, uuid, tempfile, datetime, logging
+import unittest, os, sys, filecmp, uuid, tempfile
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -75,14 +75,13 @@ class TestDssApi(unittest.TestCase):
 
         # Test put-files
         file_uuid = str(uuid.uuid4())
-        # file_version = datetime.datetime.now().isoformat()
         bundle_uuid = str(uuid.uuid4())
         source_url = "s3://{}/{}/{}".format(self.staging_bucket, file_['uuid'], file_['name'])
         res = client.put_file(uuid=file_uuid, creator_uid=1, bundle_uuid=bundle_uuid, source_url=source_url)
 
         # Test put-bundles
         files = [{'indexed': True,
-                  'name': file_['name'],
+                  'name': "gibberish",
                   'uuid': file_uuid,
                   'version': res['version']}]
         res = client.put_bundle(uuid=bundle_uuid, files=files, creator_uid=1, replica="aws")


### PR DESCRIPTION
The server now checks whether the bundle_uuid in the file manifest matches.