### PR TITLE
Bug found when uploading a file that is size 64 * 1024 * 1024

### DIFF
--- a/test/test_dss_api.py
+++ b/test/test_dss_api.py
@@ -37,18 +37,24 @@ class TestDssApi(unittest.TestCase):
                 self.assertTrue(filecmp.cmp(uploaded_file, downloaded_file, False))
 
     def test_python_upload_lg_file(self):
-        with TemporaryDirectory() as src_dir, TemporaryDirectory() as dest_dir:
-            with tempfile.NamedTemporaryFile(dir=src_dir, suffix=".bin") as fh:
-                fh.write(os.urandom(64 * 1024 * 1024 + 1))
-                fh.flush()
+        sizes = [64 * 1024 * 1024 - 1,
+                 64 * 1024 * 1024 + 1,
+                 64 * 1024 * 1024,
+                 ]
+        data = os.urandom(max(sizes))
+        for size in sizes:
+            with TemporaryDirectory() as src_dir, TemporaryDirectory() as dest_dir:
+                with tempfile.NamedTemporaryFile(dir=src_dir, suffix=".bin") as fh:
+                    fh.write(data[:size-1])
+                    fh.flush()
 
-                client = hca.dss.DSSClient()
-                bundle_output = client.upload(src_dir=src_dir, replica="aws", staging_bucket=self.staging_bucket)
+                    client = hca.dss.DSSClient()
+                    bundle_output = client.upload(src_dir=src_dir, replica="aws", staging_bucket=self.staging_bucket)
 
-                client.download(bundle_output['bundle_uuid'], replica="aws", dest_name=dest_dir)
+                    client.download(bundle_output['bundle_uuid'], replica="aws", dest_name=dest_dir)
 
-                downloaded_file = os.path.join(dest_dir, os.path.basename(fh.name))
-                self.assertTrue(filecmp.cmp(fh.name, downloaded_file, False))
+                    downloaded_file = os.path.join(dest_dir, os.path.basename(fh.name))
+                    self.assertTrue(filecmp.cmp(fh.name, downloaded_file, False))
 
     def test_python_bindings(self):
         bundle_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bundle")


### PR DESCRIPTION
I modified one of the unit test to reproduce the bug. 

## Stacktrace
```
======================================================================
ERROR: test_python_upload_lg_file (test.test_dss_api.TestDssApi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/requests/adapters.py", line 440, in send
    timeout=timeout
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 668, in urlopen
    **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 732, in urlopen
    body_pos=body_pos, **response_kw)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/connectionpool.py", line 712, in urlopen
    retries = retries.increment(method, url, response=response, _pool=self)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='dss.dev.data.humancellatlas.org', port=443): Max retries exceeded with url: /v1/files/7ccc82a3-d25d-4155-8fd3-8079a40f8556 (Caused by ResponseError('too many 500 error responses',))
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/build/HumanCellAtlas/dcp-cli/test/test_dss_api.py", line 52, in test_python_upload_lg_file
    bundle_output = client.upload(src_dir=src_dir, replica="aws", staging_bucket=self.staging_bucket)
  File "/home/travis/build/HumanCellAtlas/dcp-cli/hca/dss/__init__.py", line 159, in upload
    source_url=source_url
  File "/home/travis/build/HumanCellAtlas/dcp-cli/hca/util/__init__.py", line 138, in _request
    timeout=self.timeout_policy)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/home/travis/virtualenv/python3.5.5/lib/python3.5/site-packages/requests/adapters.py", line 499, in send
    raise RetryError(e, request=request)
requests.exceptions.RetryError: HTTPSConnectionPool(host='dss.dev.data.humancellatlas.org', port=443): Max retries exceeded with url: /v1/files/7ccc82a3-d25d-4155-8fd3-8079a40f8556 (Caused by ResponseError('too many 500 error responses',))
```