### PR TITLE
Add `download-manifest` command; file globbing for `download`

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -430,8 +430,12 @@ class SwaggerClient(object):
     def _get_command_arg_settings(self, param_data):
         if param_data.default is Parameter.empty:
             return dict(required=True)
+        elif param_data.default is True:
+            return dict(action='store_false', default=True)
+        elif param_data.default is False:
+            return dict(action='store_true', default=False)
         elif isinstance(param_data.default, (list, tuple)):
-            return dict(nargs="+", required=True, default=param_data.default)
+            return dict(nargs="+", default=param_data.default)
         else:
             return dict(type=type(param_data.default), default=param_data.default)
 

--- a/hca/util/compat.py
+++ b/hca/util/compat.py
@@ -1,5 +1,29 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os, sys, datetime, errno
+import os
+import re
+import sys
 
 USING_PYTHON2 = True if sys.version_info < (3, 0) else False
+
+if USING_PYTHON2:
+    # https://github.com/python/cpython/blob/master/Lib/glob.py#L142
+    _magic_check = re.compile('([*?[])')
+    _magic_check_bytes = re.compile(b'([*?[])')
+
+    # https://github.com/python/cpython/blob/master/Lib/glob.py#L161
+    def glob_escape(pathname):
+        """Escape all special characters.
+        """
+        # Escaping is done by wrapping any of "*?[" between square brackets.
+        # Metacharacters do not work in the drive part and shouldn't be escaped.
+        drive, pathname = os.path.splitdrive(pathname)
+        if isinstance(pathname, bytes):
+            pathname = _magic_check_bytes.sub(br'[\1]', pathname)
+        else:
+            pathname = _magic_check.sub(r'[\1]', pathname)
+        return drive + pathname
+else:
+    from glob import escape as glob_escape
+
+__all__ = ('USING_PYTHON2', 'glob_escape')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ pyyaml
 responses
 backports.tempfile
 mock
+unittest2
 -r requirements.txt


### PR DESCRIPTION
Fixes #123

Adds the ability to download files from a DSS instance given a tab-separated file with references to said files. Intuitively, one would think that the TSV only needs to contain a list of file FQIDs. So why did I not go this route? Here is the train of thought that led to the current implementation:

1) From a usability perspective it is desirable that a downloaded file is assigned the same name that the file had at submission time.

2) That file name is tracked in the bundle manifest, not the file object. Given a file's FQID one would also need the FQID of a bundle that references the file. There could be more than one bundle referencing a file. The file name could be different between those bundles. To be unambiquous, the manifest has to contain two FQIDs per row, that of  of the file and that of a bundle containing the file and assigning it a name.

3) There's another catch: Two distinct files in in two distinct bundles could be assigned the same name. In order to download them both into a single directory, one would need to apply some disambiguation to the file's name. Appending the file's FQID comes to mind, or placing the files into separate sub-directories. The former seems inconvenient. For the latter, the obvious choice for naming the subdirectory is the bundle UUID. The resulting directory layout is identical to the one produced by the existing single-bundle `download` command. Using it for both `download` and `download-manifest` would enable a synergy between them: the user could augment the result of a manifest download by later running `download` on individual bundles.

4) To achieve this, we could simply extend the existing `download` command to accept a set of file FQIDs that limits what files are being downloaded. While this would be sufficient to support the manifest download, we can kill two birds with one stone by using file names instead of identifiers to restrict the download. That way, the user can say `hca download --bundle-uuid $UUID --version $version --files SRR2967608_1.fastq.gz`.

5) With just a tiny bit more code we can extend that mechanism from file names to shell patterns (globs). Now the user can say `hca download --bundle-uuid $UUID --version $version --files *.fastq.gz`. That is a big boost in convenience and control. Globs also make it easy to assign a backwards-compatible default value to the new `--files` parameter: `*`. That's intuitive and self-explanatory. If the `--files` parameter only accepted literal file names, the default would have to be a less intuitive value, like `None` or the empty string.

6) In order to safely use file names instead of FQIDs for selecting which file to download from a bundle, we need to make sure that those file names are actually unique within the bundle. However, this uniqueness constraint is not just requirement for this feature. It is in fact a requirement for bundle downloads in general. If we don't prevent conflicting file names in a bundle, the existing `download` command will happily overwrite files of the same name, or worse, mix data from two remote files into one local file, in the case of a resumed download. Once we address that, the triple `(bundle_uuid, bundle_version, file_name)` is a safe and stable identifier. There is a ticket open in the data-store project that aims to enforce uniqueness of file names in newly submitted bundles. This PR adds code to handle any existing bundles that may have file name collisions. There is a twist with respect to case-insensitive file systems but the respective commit handles that.

Related PRs:

https://github.com/HumanCellAtlas/data-store/issues/1268
https://github.com/HumanCellAtlas/data-store/issues/1331