### PR TITLE
IAM-Not: get temporary aws credentials on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ version: hca/version.py
 hca/version.py: setup.py
 	echo "__version__ = '$$(python setup.py --version)'" > $@
 
-install: clean version
+build: version
 	-rm -rf dist
 	python setup.py bdist_wheel
+
+install: clean build
 	pip install --upgrade dist/*.whl
 
 init_docs:

--- a/hca/upload/__init__.py
+++ b/hca/upload/__init__.py
@@ -25,14 +25,9 @@ def forget_area(uuid_or_alias):
     """
     Remove an area from our cache of upload areas.
     """
-    matching_areas = UploadArea.areas_matching_alias(alias=uuid_or_alias)
-    if len(matching_areas) == 0:
-        raise UploadException("Sorry I don't recognize area \"%s\"" % (uuid_or_alias,))
-    elif len(matching_areas) == 1:
-        matching_areas[0].forget()
-        return matching_areas[0]
-    else:
-        raise UploadException("\"%s\" matches more than one area, please provide more characters." % (uuid_or_alias,))
+    area = UploadArea.from_alias(uuid_or_alias)
+    area.forget()
+    return area
 
 
 def list_current_area(detail=False):

--- a/hca/upload/__init__.py
+++ b/hca/upload/__init__.py
@@ -1,6 +1,5 @@
 from .upload_config import UploadConfig
 from .upload_area import UploadArea
-from .upload_area_urn import UploadAreaURN
 from .exceptions import UploadException
 
 
@@ -8,15 +7,15 @@ def select_area(**kwargs):
     """
     Select a new destination for uploads, using the UUID of a formerly selected area, or the URN of a new upload area.
 
-    :param urn: An Upload Area URN.
+    :param uri: An Upload Area URI.
     :param uuid: A RFC4122-compliant ID of the upload area.
     """
     if 'uuid' in kwargs:
         area = UploadArea(uuid=kwargs['uuid'])
-    elif 'urn' in kwargs:
-        area = UploadArea(urn=UploadAreaURN(kwargs['urn']))
+    elif 'uri' in kwargs:
+        area = UploadArea(uri=kwargs['uri'])
     else:
-        raise UploadException("You must supply a UUID or URN")
+        raise UploadException("You must supply a UUID or URI")
     area.select()
 
 

--- a/hca/upload/__init__.py
+++ b/hca/upload/__init__.py
@@ -1,6 +1,8 @@
+from .credentials_manager import CredentialsManager
 from .upload_config import UploadConfig
-from .upload_area import UploadArea
+from .upload_area import UploadArea, UploadAreaURI
 from .exceptions import UploadException
+from .api_client import ApiClient
 
 
 def select_area(**kwargs):
@@ -73,3 +75,12 @@ def upload_file(file_path,
                      use_transfer_acceleration=use_transfer_acceleration,
                      report_progress=report_progress,
                      dcp_type=dcp_type)
+
+
+def get_credentials(area_uuid):
+    """
+    Return a set of credentials that may be used to access the Upload Area.
+    """
+    area = UploadArea(uuid=area_uuid)
+    creds_mgr = CredentialsManager(area)
+    return creds_mgr.get_credentials()

--- a/hca/upload/api_client.py
+++ b/hca/upload/api_client.py
@@ -15,7 +15,18 @@ class ApiClient:
         response = requests.put(url, data=(json.dumps(file_list)))
         if not response.ok:
             raise RuntimeError(
-                "GET {url} returned {status}, {content}".format(
+                "PUT {url} returned {status}, {content}".format(
+                    url=url,
+                    status=response.status_code,
+                    content=response.content))
+        return response.json()
+
+    def credentials(self, area_uuid):
+        url = "{api_url_base}/area/{uuid}/credentials".format(api_url_base=self.api_url_base, uuid=area_uuid)
+        response = requests.post(url)
+        if not response.status_code == requests.codes.created:
+            raise RuntimeError(
+                "POST {url} returned {status}, {content}".format(
                     url=url,
                     status=response.status_code,
                     content=response.content))

--- a/hca/upload/cli/__init__.py
+++ b/hca/upload/cli/__init__.py
@@ -3,6 +3,7 @@ from .list_areas_command import ListAreasCommand
 from .list_area_command import ListAreaCommand
 from .upload_command import UploadCommand
 from .forget_command import ForgetCommand
+from .creds_command import CredsCommand
 from .common import UploadCLICommand
 
 
@@ -24,3 +25,4 @@ def add_commands(subparsers):
     ListAreaCommand.add_parser(upload_subparsers)
     ListAreasCommand.add_parser(upload_subparsers)
     ForgetCommand.add_parser(upload_subparsers)
+    CredsCommand.add_parser(upload_subparsers)

--- a/hca/upload/cli/creds_command.py
+++ b/hca/upload/cli/creds_command.py
@@ -1,0 +1,32 @@
+from .. import get_credentials, UploadArea, UploadException
+from .common import UploadCLICommand
+
+
+class CredsCommand(UploadCLICommand):
+    """
+    Get/show AWS credentials for access to Upload Area
+    """
+    @classmethod
+    def add_parser(cls, upload_subparsers):
+        forget_parser = upload_subparsers.add_parser(
+            'creds',
+            description=cls.__doc__,
+            help=cls.__doc__
+        )
+        forget_parser.add_argument('uuid_or_alias',
+                                   help="Full or partial (alias) UUID of an upload area.")
+        forget_parser.set_defaults(entry_point=CredsCommand)
+
+    def __init__(self, args):
+        alias = args.uuid_or_alias
+        try:
+
+            area = UploadArea.from_alias(alias)
+            creds = get_credentials(area.uuid)
+            print("SAM: ", creds)
+            print("AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s" % (
+                creds['aws_access_key_id'], creds['aws_secret_access_key'], creds['aws_session_token']
+            ))
+        except UploadException as e:
+            print(str(e))
+            exit(1)

--- a/hca/upload/cli/select_command.py
+++ b/hca/upload/cli/select_command.py
@@ -1,4 +1,3 @@
-from ..upload_area_urn import UploadAreaURN
 from ..upload_area import UploadArea
 from .common import UploadCLICommand
 
@@ -14,18 +13,18 @@ class SelectCommand(UploadCLICommand):
             help=cls.__doc__,
             description=cls.__doc__
         )
-        select_parser.add_argument('urn_or_alias',
-                                   help="Full URN of an upload area, or short alias.")
+        select_parser.add_argument('uri_or_alias',
+                                   help="S3 URI of an upload area, or short alias.")
         select_parser.set_defaults(entry_point=SelectCommand)
 
     def __init__(self, args):
-        if args.urn_or_alias.find(':') == -1:  # alias
-            self._select_area_by_alias(args.urn_or_alias)
-        else:  # URN
-            self._save_and_select_area_by_urn(args.urn_or_alias)
+        if args.uri_or_alias.startswith('s3://'):  # URI
+            self._save_and_select_area_by_uri(args.uri_or_alias)
+        else:  # alias
+            self._select_area_by_alias(args.uri_or_alias)
 
-    def _save_and_select_area_by_urn(self, urn_string):
-        area = UploadArea(urn=UploadAreaURN(urn_string))
+    def _save_and_select_area_by_uri(self, uri_string):
+        area = UploadArea(uri=uri_string)
         area.select()
         print("Upload area %s selected." % area.uuid)
         print("In future you may refer to this upload area using the alias \"%s\"" % area.unique_prefix)

--- a/hca/upload/cli/select_command.py
+++ b/hca/upload/cli/select_command.py
@@ -1,4 +1,4 @@
-from ..upload_area import UploadArea
+from ..upload_area import UploadArea, UploadException
 from .common import UploadCLICommand
 
 
@@ -30,11 +30,8 @@ class SelectCommand(UploadCLICommand):
         print("In future you may refer to this upload area using the alias \"%s\"" % area.unique_prefix)
 
     def _select_area_by_alias(self, alias):
-        matching_areas = UploadArea.areas_matching_alias(alias)
-        if len(matching_areas) == 0:
-            print("Sorry I don't recognize area \"%s\"" % (alias,))
-        elif len(matching_areas) == 1:
-            matching_areas[0].select()
-            print("Upload area %s selected." % matching_areas[0].uuid)
-        else:
-            print("\"%s\" matches more than one area, please provide more characters." % (alias,))
+        try:
+            area = UploadArea.from_alias(alias)
+            area.select()
+        except UploadException as e:
+            print(str(e))

--- a/hca/upload/cli/upload_command.py
+++ b/hca/upload/cli/upload_command.py
@@ -56,7 +56,7 @@ class UploadCommand(UploadCLICommand):
         self.config = UploadConfig()
         if not self.config.current_area:
             sys.stderr.write("\nThere is no upload area selected.\n" +
-                             "Please select one with \"{cmdname} upload select <urn_or_alias>\"\n\n".format(
+                             "Please select one with \"{cmdname} upload select <uri_or_alias>\"\n\n".format(
                                  cmdname=sys.argv[0]))
             exit(1)
 

--- a/hca/upload/credentials_manager.py
+++ b/hca/upload/credentials_manager.py
@@ -1,0 +1,53 @@
+import boto3
+from botocore.errorfactory import ClientError
+
+from .api_client import ApiClient
+from .upload_config import UploadConfig
+
+
+class CredentialsManager:
+
+    def __init__(self, upload_area):
+        self.area = upload_area
+
+    def get_credentials(self):
+        """
+        Get credentials from Config, or request them from the API, then store them in Config.
+
+        Note that we check the credentials are good using get-caller-identity before returning them,
+        instead of providing a decorator that will catch ExpiredToken and retry.
+        This is because some of the Upload methods return generators, which mean the exception happens
+        outside of our control.
+        """
+        config = UploadConfig()
+        our_info = config.areas[self.area.uuid]
+        if 'credentials' not in our_info or not self._credentials_are_good(our_info['credentials']):
+            self._get_new_credentials()
+        return our_info['credentials']
+
+    def delete_credentials(self):
+        config = UploadConfig()
+        del config.areas[self.area.uuid]['credentials']
+        config.save()
+
+    def _credentials_are_good(self, credentials):
+        try:
+            session = boto3.session.Session(**credentials)
+            sts = session.client('sts')
+            sts.get_caller_identity()
+            return True
+        except ClientError:
+            return False
+
+    def _get_new_credentials(self):
+        api = ApiClient(deployment_stage=self.area.deployment_stage)
+        raw_creds = api.credentials(area_uuid=self.area.uuid)
+        creds = {
+            'aws_access_key_id': raw_creds['AccessKeyId'],
+            'aws_secret_access_key': raw_creds['SecretAccessKey'],
+            'aws_session_token': raw_creds['SessionToken']
+        }
+        config = UploadConfig()
+        config.areas[self.area.uuid]['credentials'] = creds
+        config.save()
+        return creds

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -41,6 +41,17 @@ class UploadArea:
         return [cls(uuid=uuid) for uuid in UploadConfig().areas.keys()]
 
     @classmethod
+    def from_alias(cls, uuid_or_alias):
+        matching_areas = UploadArea.areas_matching_alias(alias=uuid_or_alias)
+        if len(matching_areas) == 0:
+            raise UploadException("Sorry I don't recognize area \"%s\"" % (uuid_or_alias,))
+        elif len(matching_areas) == 1:
+            return matching_areas[0]
+        else:
+            raise UploadException(
+                "\"%s\" matches more than one area, please provide more characters." % (uuid_or_alias,))
+
+    @classmethod
     def areas_matching_alias(cls, alias):
         return [cls(uuid=uuid) for uuid in UploadConfig().areas if re.match(alias, uuid)]
 

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -14,11 +14,11 @@ class UploadArea:
 
     @classmethod
     def all(cls):
-        return [cls(uuid=uuid) for uuid in UploadConfig().areas()]
+        return [cls(uuid=uuid) for uuid in UploadConfig().areas]
 
     @classmethod
     def areas_matching_alias(cls, alias):
-        return [cls(uuid=uuid) for uuid in UploadConfig().areas() if re.match(alias, uuid)]
+        return [cls(uuid=uuid) for uuid in UploadConfig().areas if re.match(alias, uuid)]
 
     def __init__(self, **kwargs):
         """
@@ -29,7 +29,7 @@ class UploadArea:
         """
         if 'uuid' in kwargs:
             self.uuid = kwargs['uuid']
-            areas = UploadConfig().areas()
+            areas = UploadConfig().areas
             if self.uuid not in areas:
                 raise UploadException("I'm not aware of upload area \"%s\"" % self.uuid)
             self.urn = UploadAreaURN(areas[self.uuid])

--- a/hca/upload/upload_config.py
+++ b/hca/upload/upload_config.py
@@ -1,4 +1,8 @@
+import six
+
 from .. import get_config
+
+from .upload_area_urn import UploadAreaURN
 
 
 class UploadConfig:
@@ -12,6 +16,7 @@ class UploadConfig:
     def __init__(self):
         self._load_config()
         self._set_defaults()
+        self._convert_to_uris()  # Remove in a month or two
 
     def _load_config(self):
         self._config = get_config()
@@ -45,9 +50,9 @@ class UploadConfig:
     def upload_service_api_url_template(self):
         return self._config.upload.upload_service_api_url_template
 
-    def add_area(self, urn):
-        if urn.urn not in self._config.upload.areas:
-            self._config.upload.areas[urn.uuid] = urn.urn
+    def add_area(self, uri):
+        if uri.area_uuid not in self._config.upload.areas:
+            self._config.upload.areas[uri.area_uuid] = {'uri': uri.uri}
         self.save()
 
     def select_area(self, area_uuid):
@@ -63,3 +68,25 @@ class UploadConfig:
 
     def save(self):
         self._config.save()
+
+    """
+    Convert:
+      "areas": {
+        "deadbeef-dead-dead-dead-beeeeeeeeef": "dcp:upl:aws:dev:deadbeef-dead-dead-dead-beeeeeeeeeef:ENCRYPTEDCREDS"
+      }
+      to
+      "areas": {
+        "deadbeef-dead-dead-dead-beeeeeeeeeef": {
+          "uri": "s3://org-humancellatlas-upload-dev/deadbeef-dead-dead-dead-beeeeeeeeeef/"
+        }
+      }
+    """
+    def _convert_to_uris(self):
+        for area_id, area_data in self.areas.items():
+            if isinstance(area_data, six.text_type):
+                urn = UploadAreaURN(area_data)
+                bucket_name = self.bucket_name_template.format(deployment_stage=urn.deployment_stage)
+                self.areas[area_id] = {
+                    "uri": "s3://{bucket_name}/{area_id}/".format(bucket_name=bucket_name, area_id=area_id)
+                }
+        self.save()

--- a/hca/upload/upload_config.py
+++ b/hca/upload/upload_config.py
@@ -29,8 +29,21 @@ class UploadConfig:
             self._config.upload.upload_service_api_url_template = self.DEFAULT_UPLOAD_SERVICE_API_URL_TEMPLATE
         self.save()
 
+    @property
     def areas(self):
         return self._config.upload.areas
+
+    @property
+    def current_area(self):
+        return self._config.upload.current_area
+
+    @property
+    def bucket_name_template(self):
+        return self._config.upload.bucket_name_template
+
+    @property
+    def upload_service_api_url_template(self):
+        return self._config.upload.upload_service_api_url_template
 
     def add_area(self, urn):
         if urn.urn not in self._config.upload.areas:
@@ -47,18 +60,6 @@ class UploadConfig:
         if area_uuid in self._config.upload.areas:
             del self._config.upload.areas[area_uuid]
             self.save()
-
-    @property
-    def current_area(self):
-        return self._config.upload.current_area
-
-    @property
-    def bucket_name_template(self):
-        return self._config.upload.bucket_name_template
-
-    @property
-    def upload_service_api_url_template(self):
-        return self._config.upload.upload_service_api_url_template
 
     def save(self):
         self._config.save()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -33,18 +33,33 @@ class CapturingIO:
         return self.buffer.read()
 
 
+class TweakResetter:
+    """
+    May be used with 'with', in the decorator (below) or manually:
+    """
+
+    def __enter__(self):
+        self.save_config()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore_config()
+
+    def save_config(self):
+        config = hca.get_config()
+        self.backup = pickle.dumps(config)
+
+    def restore_config(self):
+        # The save method of the previous config manager will be called as an atexit handler.
+        # Invalidate its config file path so it fails to save the old config.
+        hca.config._config._user_config_home = "/tmp"
+        # Reload config after changes made.
+        hca.config._config = pickle.loads(self.backup)
+        hca.get_config().save()
+
+
 def reset_tweak_changes(f):
     @wraps(f)
     def save_and_restore_tweak_config(*args, **kwargs):
-        config = hca.get_config()
-        backup = pickle.dumps(config)
-        try:
+        with TweakResetter():
             f(*args, **kwargs)
-        finally:
-            # The save method of the previous config manager will be called as an atexit handler.
-            # Invalidate its config file path so it fails to save the old config.
-            hca.config._config._user_config_home = "/tmp"
-            # Reload config after changes made.
-            hca.config._config = pickle.loads(backup)
-            hca.get_config().save()
     return save_and_restore_tweak_config

--- a/test/upload/__init__.py
+++ b/test/upload/__init__.py
@@ -15,15 +15,6 @@ UPLOAD_BUCKET_NAME_TEMPLATE = 'bogo-bucket-{deployment_stage}'
 TEST_UPLOAD_BUCKET = UPLOAD_BUCKET_NAME_TEMPLATE.format(deployment_stage=os.environ['DEPLOYMENT_STAGE'])
 
 
-def setup_tweak_config():
-    config = hca.get_config()
-    config.upload = {
-        'areas': {},
-        'bucket_name_template': UPLOAD_BUCKET_NAME_TEMPLATE
-    }
-    config.save()
-
-
 def mock_current_upload_area():
     area = mock_upload_area()
     area.select()
@@ -53,7 +44,18 @@ class UploadTestCase(unittest.TestCase):
         # Don't crush Tweak config
         self.tweak_resetter = TweakResetter()
         self.tweak_resetter.save_config()
+        # Clean config
+        self._setup_tweak_config()
 
     def tearDown(self):
         self.s3_mock.stop()
         self.tweak_resetter.restore_config()
+
+    def _setup_tweak_config(self):
+        config = hca.get_config()
+        config.upload = {
+            'areas': {},
+            'bucket_name_template': UPLOAD_BUCKET_NAME_TEMPLATE
+        }
+        config.save()
+

--- a/test/upload/__init__.py
+++ b/test/upload/__init__.py
@@ -6,6 +6,8 @@ import unittest
 
 from moto import mock_s3
 
+from .. import TweakResetter
+
 import hca
 from hca.upload import UploadArea, UploadAreaURN
 
@@ -48,6 +50,10 @@ class UploadTestCase(unittest.TestCase):
         # Setup mock AWS
         self.s3_mock = mock_s3()
         self.s3_mock.start()
+        # Don't crush Tweak config
+        self.tweak_resetter = TweakResetter()
+        self.tweak_resetter.save_config()
 
     def tearDown(self):
         self.s3_mock.stop()
+        self.tweak_resetter.restore_config()

--- a/test/upload/__init__.py
+++ b/test/upload/__init__.py
@@ -2,8 +2,9 @@ import base64
 import json
 import os
 import uuid
+import unittest
 
-import tweak
+from moto import mock_s3
 
 import hca
 from hca.upload import UploadArea, UploadAreaURN
@@ -39,3 +40,14 @@ def mock_upload_area(area_uuid=None):
     urn = "dcp:upl:aws:{}:{}:{}".format(stage, area_uuid, encoded_creds)
     area = UploadArea(urn=UploadAreaURN(urn))
     return area
+
+
+class UploadTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Setup mock AWS
+        self.s3_mock = mock_s3()
+        self.s3_mock.start()
+
+    def tearDown(self):
+        self.s3_mock.stop()

--- a/test/upload/__init__.py
+++ b/test/upload/__init__.py
@@ -1,30 +1,31 @@
-import base64
-import json
+import re
 import uuid
 import unittest
 
 import boto3
-from moto import mock_s3
+from moto import mock_s3, mock_sts
+import responses
+
 
 from .. import TweakResetter
 
 import hca
-from hca.upload import UploadArea, UploadAreaURN
+from hca.upload import UploadArea
 
 
 class UploadTestCase(unittest.TestCase):
 
-    UPLOAD_BUCKET_NAME_TEMPLATE = 'bogo-bucket-{deployment_stage}'
+    UPLOAD_BUCKET_NAME_TEMPLATE = 'org-bogo-upload-{deployment_stage}'
 
     def setUp(self):
         # Setup mock AWS
         self.s3_mock = mock_s3()
         self.s3_mock.start()
+        self.sts_mock = mock_sts()
+        self.sts_mock.start()
         # Don't crush Tweak config
         self.tweak_resetter = TweakResetter()
         self.tweak_resetter.save_config()
-        # Clean config
-        self._setup_tweak_config()
         # Upload bucket
         self.deployment_stage = 'test'
         self.upload_bucket_name = self.UPLOAD_BUCKET_NAME_TEMPLATE.format(deployment_stage=self.deployment_stage)
@@ -33,6 +34,7 @@ class UploadTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.s3_mock.stop()
+        self.sts_mock.stop()
         self.tweak_resetter.restore_config()
 
     def mock_current_upload_area(self):
@@ -40,17 +42,34 @@ class UploadTestCase(unittest.TestCase):
         area.select()
         return area
 
-    def mock_upload_area(self, area_uuid=None):
+    def mock_current_upload_area(self, area_uuid=None, bucket_name=None):
+        area = self.mock_upload_area(area_uuid=area_uuid, bucket_name=bucket_name)
+        area.select()
+        return area
+
+    def mock_upload_area(self, area_uuid=None, bucket_name=None):
         """
-        Create a UUID and URN for a fake upload area, store it in Tweak config.
+        Create a UUID and URI for a fake upload area, store it in Tweak config.
         """
         if not area_uuid:
             area_uuid = str(uuid.uuid4())
-        creds = {'AWS_ACCESS_KEY_ID': 'foo', 'AWS_SECRET_ACCESS_KEY': 'bar'}
-        encoded_creds = base64.b64encode(json.dumps(creds).encode('ascii')).decode('ascii')
-        urn = "dcp:upl:aws:{}:{}:{}".format(self.deployment_stage, area_uuid, encoded_creds)
-        area = UploadArea(urn=UploadAreaURN(urn))
+        if not bucket_name:
+            bucket_name = self.UPLOAD_BUCKET_NAME_TEMPLATE.format(deployment_stage=self.deployment_stage)
+        area = UploadArea(uri="s3://{bucket}/{uuid}/".format(bucket=bucket_name, uuid=area_uuid))
         return area
+
+    def simulate_credentials_api(self, area_uuid,
+                                 api_host="upload.{stage}.data.humancellatlas.org",
+                                 stage='test'):
+        if re.search('\{stage\}', api_host):
+            api_host = api_host.format(stage=stage)
+
+        creds_url = 'https://{api_host}/v1/area/{uuid}/credentials'.format(api_host=api_host, uuid=area_uuid)
+
+        responses.add(responses.POST, creds_url,
+                      json={'AccessKeyId': 'foo', 'SecretAccessKey': 'bar', 'SessionToken': 'baz'},
+                      status=201)
+        return creds_url
 
     def _setup_tweak_config(self):
         config = hca.get_config()
@@ -59,4 +78,3 @@ class UploadTestCase(unittest.TestCase):
             'bucket_name_template': self.UPLOAD_BUCKET_NAME_TEMPLATE
         }
         config.save()
-

--- a/test/upload/cli/test_config.py
+++ b/test/upload/cli/test_config.py
@@ -6,7 +6,6 @@ from ... import CapturingIO
 from .. import UploadTestCase
 
 import hca
-
 from hca.upload.cli.list_area_command import ListAreaCommand
 
 
@@ -18,30 +17,19 @@ class TestConfig(UploadTestCase):
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
 
     @responses.activate
-    def test_we_access_hca_url_by_default(self):
-
-        list_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/files_info'.format(
-            stage=self.deployment_stage,
-            uuid=self.area.uuid)
-        responses.add(responses.PUT, list_url, json={}, status=200)
-
-        with CapturingIO('stdout') as stdout:
-            ListAreaCommand(Namespace(long=True))
-
-        self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(responses.calls[0].request.url, list_url)
-
-    @responses.activate
-    def test_we_access_configured_upload_service_api_endpoint(self):
+    def test_upload_service_api_url_template_is_obeyed(self):
         config = hca.get_config()
-        config.upload.upload_service_api_url_template = "http://upload.example.com/v1"
+        config.upload.upload_service_api_url_template = "https://upload.example.com/v1"
         config.save()
 
-        list_url = 'http://upload.example.com/v1/area/{uuid}/files_info'.format(uuid=self.area.uuid)
+        creds_url = self.simulate_credentials_api(self.area.uuid, api_host="upload.example.com")
+
+        list_url = 'https://upload.example.com/v1/area/{uuid}/files_info'.format(uuid=self.area.uuid)
         responses.add(responses.PUT, list_url, json={}, status=200)
 
         with CapturingIO('stdout') as stdout:
             ListAreaCommand(Namespace(long=True))
 
-        self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(responses.calls[0].request.url, list_url)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[0].request.url, creds_url)
+        self.assertEqual(responses.calls[1].request.url, list_url)

--- a/test/upload/cli/test_config.py
+++ b/test/upload/cli/test_config.py
@@ -1,26 +1,20 @@
-import os
-import sys
-import unittest
 from argparse import Namespace
 
 import responses
 import boto3
-from moto import mock_s3
 
 from ... import CapturingIO, reset_tweak_changes
-from .. import mock_current_upload_area
+from .. import UploadTestCase, mock_current_upload_area
 
 import hca
 
 from hca.upload.cli.list_area_command import ListAreaCommand
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig(UploadTestCase):
 
     def setUp(self):
-        self.s3_mock = mock_s3()
-        self.s3_mock.start()
-
+        super(self.__class__, self).setUp()
         self.deployment_stage = 'test'
         self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
         self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
@@ -28,9 +22,6 @@ class TestConfig(unittest.TestCase):
 
         self.area = mock_current_upload_area()
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
-
-    def tearDown(self):
-        self.s3_mock.stop()
 
     @reset_tweak_changes
     @responses.activate

--- a/test/upload/cli/test_config.py
+++ b/test/upload/cli/test_config.py
@@ -1,10 +1,9 @@
 from argparse import Namespace
 
 import responses
-import boto3
 
 from ... import CapturingIO
-from .. import UploadTestCase, mock_current_upload_area
+from .. import UploadTestCase
 
 import hca
 
@@ -15,12 +14,7 @@ class TestConfig(UploadTestCase):
 
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.deployment_stage = 'test'
-        self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
-        self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
-        self.upload_bucket.create()
-
-        self.area = mock_current_upload_area()
+        self.area = self.mock_current_upload_area()
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
 
     @responses.activate

--- a/test/upload/cli/test_config.py
+++ b/test/upload/cli/test_config.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 import responses
 import boto3
 
-from ... import CapturingIO, reset_tweak_changes
+from ... import CapturingIO
 from .. import UploadTestCase, mock_current_upload_area
 
 import hca
@@ -23,7 +23,6 @@ class TestConfig(UploadTestCase):
         self.area = mock_current_upload_area()
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
 
-    @reset_tweak_changes
     @responses.activate
     def test_we_access_hca_url_by_default(self):
 
@@ -38,7 +37,6 @@ class TestConfig(UploadTestCase):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, list_url)
 
-    @reset_tweak_changes
     @responses.activate
     def test_we_access_configured_upload_service_api_endpoint(self):
         config = hca.get_config()

--- a/test/upload/cli/test_creds.py
+++ b/test/upload/cli/test_creds.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from argparse import Namespace
+
+import responses
+import six
+
+from ... import CapturingIO
+from .. import UploadTestCase
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from hca.upload.cli.creds_command import CredsCommand
+
+
+class TestUploadCliCredsCommand(UploadTestCase):
+
+    @responses.activate
+    def test_creds(self):
+        area = self.mock_current_upload_area()
+        self.simulate_credentials_api(area_uuid=area.uuid)
+
+        with CapturingIO('stdout') as stdout:
+            args = Namespace(uuid_or_alias=area.uuid)
+            CredsCommand(args)
+
+        six.assertRegex(self, stdout.captured(), "AWS_ACCESS_KEY_ID=")
+        six.assertRegex(self, stdout.captured(), "AWS_SECRET_ACCESS_KEY=")
+        six.assertRegex(self, stdout.captured(), "AWS_SESSION_TOKEN=")

--- a/test/upload/cli/test_forget.py
+++ b/test/upload/cli/test_forget.py
@@ -1,12 +1,11 @@
 import os
 import sys
-import unittest
 from argparse import Namespace
 
 import six
 
 from ... import CapturingIO, reset_tweak_changes
-from .. import mock_current_upload_area, mock_upload_area
+from .. import UploadTestCase, mock_current_upload_area, mock_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -15,7 +14,7 @@ from hca.upload import UploadConfig
 from hca.upload.cli.forget_command import ForgetCommand
 
 
-class TestUploadCliForgetCommand(unittest.TestCase):
+class TestUploadCliForgetCommand(UploadTestCase):
 
     @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):

--- a/test/upload/cli/test_forget.py
+++ b/test/upload/cli/test_forget.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import six
 
-from ... import CapturingIO, reset_tweak_changes
+from ... import CapturingIO
 from .. import UploadTestCase, mock_current_upload_area, mock_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -16,7 +16,6 @@ from hca.upload.cli.forget_command import ForgetCommand
 
 class TestUploadCliForgetCommand(UploadTestCase):
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
         area = mock_current_upload_area()
         self.assertIn(area.uuid, UploadConfig().areas)
@@ -29,7 +28,6 @@ class TestUploadCliForgetCommand(UploadTestCase):
         self.assertNotIn(area.uuid, UploadConfig().areas)
         self.assertEqual(None, UploadConfig().current_area)
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_no_areas_it_prints_a_warning(self):
 
         with CapturingIO('stdout') as stdout:
@@ -39,7 +37,6 @@ class TestUploadCliForgetCommand(UploadTestCase):
 
         six.assertRegex(self, stdout.captured(), "don't recognize area")
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_more_than_one_area_it_prints_a_warning(self):
         mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
         mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')

--- a/test/upload/cli/test_forget.py
+++ b/test/upload/cli/test_forget.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 import six
 
 from ... import CapturingIO
-from .. import UploadTestCase, mock_current_upload_area, mock_upload_area
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -17,7 +17,7 @@ from hca.upload.cli.forget_command import ForgetCommand
 class TestUploadCliForgetCommand(UploadTestCase):
 
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
-        area = mock_current_upload_area()
+        area = self.mock_current_upload_area()
         self.assertIn(area.uuid, UploadConfig().areas)
         self.assertEqual(area.uuid, UploadConfig().current_area)
 
@@ -38,8 +38,8 @@ class TestUploadCliForgetCommand(UploadTestCase):
         six.assertRegex(self, stdout.captured(), "don't recognize area")
 
     def test_when_given_an_alias_that_matches_more_than_one_area_it_prints_a_warning(self):
-        mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
-        mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')
+        self.mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
+        self.mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')
 
         with CapturingIO('stdout') as stdout:
             with self.assertRaises(SystemExit):

--- a/test/upload/cli/test_forget.py
+++ b/test/upload/cli/test_forget.py
@@ -20,14 +20,14 @@ class TestUploadCliForgetCommand(unittest.TestCase):
     @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
         area = mock_current_upload_area()
-        self.assertIn(area.uuid, UploadConfig().areas())
+        self.assertIn(area.uuid, UploadConfig().areas)
         self.assertEqual(area.uuid, UploadConfig().current_area)
 
         with CapturingIO('stdout') as stdout:
             args = Namespace(uuid_or_alias=area.uuid)
             ForgetCommand(args)
 
-        self.assertNotIn(area.uuid, UploadConfig().areas())
+        self.assertNotIn(area.uuid, UploadConfig().areas)
         self.assertEqual(None, UploadConfig().current_area)
 
     @reset_tweak_changes

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -3,7 +3,6 @@ import sys
 from argparse import Namespace
 
 import responses
-import boto3
 
 from ... import CapturingIO
 from .. import UploadTestCase
@@ -20,9 +19,12 @@ class TestUploadListAreaCommand(UploadTestCase):
         super(self.__class__, self).setUp()
         self.area = self.mock_current_upload_area()
 
+    @responses.activate
     def test_list_area_command(self):
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
         self.upload_bucket.Object('/'.join([self.area.uuid, 'sample.json'])).put(Body="foo")
+
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
 
         with CapturingIO('stdout') as stdout:
             ListAreaCommand(Namespace(long=False))
@@ -32,6 +34,8 @@ class TestUploadListAreaCommand(UploadTestCase):
     @responses.activate
     def test_list_area_command_with_long_option(self):
         self.upload_bucket.Object('/'.join([self.area.uuid, 'file1.fastq.gz'])).put(Body="foo")
+
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
 
         list_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/files_info'.format(
             stage=self.deployment_stage,

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 import responses
 import boto3
 
-from ... import CapturingIO, reset_tweak_changes
+from ... import CapturingIO
 from .. import UploadTestCase, mock_current_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -26,7 +26,6 @@ class TestUploadListAreaCommand(UploadTestCase):
     def tearDown(self):
         self.s3_mock.stop()
 
-    @reset_tweak_changes
     def test_list_area_command(self):
         area = mock_current_upload_area()
         self.upload_bucket.Object('/'.join([area.uuid, 'file1.fastq.gz'])).put(Body="foo")
@@ -37,7 +36,6 @@ class TestUploadListAreaCommand(UploadTestCase):
 
         self.assertEqual(stdout.captured(), "file1.fastq.gz\nsample.json\n")
 
-    @reset_tweak_changes
     @responses.activate
     def test_list_area_command_with_long_option(self):
         area = mock_current_upload_area()

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -3,6 +3,7 @@ import sys
 from argparse import Namespace
 
 import responses
+import six
 
 from ... import CapturingIO
 from .. import UploadTestCase
@@ -53,6 +54,6 @@ class TestUploadListAreaCommand(UploadTestCase):
         with CapturingIO('stdout') as stdout:
             ListAreaCommand(Namespace(long=True))
 
-        self.assertRegexpMatches(stdout.captured(), "size\s+123")
-        self.assertRegexpMatches(stdout.captured(), "Content-Type\s+binary/octet-stream; dcp-type=data")
-        self.assertRegexpMatches(stdout.captured(), "SHA1\s+shaaa")
+        six.assertRegex(self, stdout.captured(), "size\s+123")
+        six.assertRegex(self, stdout.captured(), "Content-Type\s+binary/octet-stream; dcp-type=data")
+        six.assertRegex(self, stdout.captured(), "SHA1\s+shaaa")

--- a/test/upload/cli/test_list_area.py
+++ b/test/upload/cli/test_list_area.py
@@ -1,14 +1,12 @@
 import os
 import sys
-import unittest
 from argparse import Namespace
 
 import responses
 import boto3
-from moto import mock_s3
 
 from ... import CapturingIO, reset_tweak_changes
-from .. import mock_current_upload_area
+from .. import UploadTestCase, mock_current_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -16,12 +14,10 @@ sys.path.insert(0, pkg_root)  # noqa
 from hca.upload.cli.list_area_command import ListAreaCommand
 
 
-class TestUploadListAreaCommand(unittest.TestCase):
+class TestUploadListAreaCommand(UploadTestCase):
 
     def setUp(self):
-        self.s3_mock = mock_s3()
-        self.s3_mock.start()
-
+        super(self.__class__, self).setUp()
         self.deployment_stage = 'test'
         self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
         self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)

--- a/test/upload/cli/test_list_areas.py
+++ b/test/upload/cli/test_list_areas.py
@@ -1,12 +1,11 @@
 import os
 import sys
-import uuid
+import unittest
 from argparse import Namespace
 
 import six
 
 from ... import CapturingIO
-from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -15,13 +14,7 @@ import hca
 from hca.upload.cli.list_areas_command import ListAreasCommand
 
 
-class TestUploadCliListAreasCommand(UploadTestCase):
-
-    def setUp(self):
-        super(self.__class__, self).setUp()
-        self.area_uuid = str(uuid.uuid4())
-        creds = "foo"
-        self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
+class TestUploadCliListAreasCommand(unittest.TestCase):
 
     def test_it_lists_areas_when_there_are_some(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
@@ -29,8 +22,8 @@ class TestUploadCliListAreasCommand(UploadTestCase):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                a_uuid: "dcp:upl:aws:dev:%s" % (a_uuid,),
-                b_uuid: "dcp:upl:aws:dev:%s" % (b_uuid,),
+                a_uuid: {'uri': "s3://foo/{}/".format(a_uuid)},
+                b_uuid: {'uri': "s3://foo/{}/".format(b_uuid)},
             },
             'current_area': a_uuid
         }

--- a/test/upload/cli/test_list_areas.py
+++ b/test/upload/cli/test_list_areas.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 
 import six
 
-from ... import CapturingIO, reset_tweak_changes
+from ... import CapturingIO
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -23,7 +23,6 @@ class TestUploadCliListAreasCommand(UploadTestCase):
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
 
-    @reset_tweak_changes
     def test_it_lists_areas_when_there_are_some(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         b_uuid = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'

--- a/test/upload/cli/test_list_areas.py
+++ b/test/upload/cli/test_list_areas.py
@@ -1,13 +1,12 @@
 import os
 import sys
-import unittest
 import uuid
 from argparse import Namespace
 
-import tweak
 import six
 
 from ... import CapturingIO, reset_tweak_changes
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -16,9 +15,10 @@ import hca
 from hca.upload.cli.list_areas_command import ListAreasCommand
 
 
-class TestUploadCliListAreasCommand(unittest.TestCase):
+class TestUploadCliListAreasCommand(UploadTestCase):
 
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)

--- a/test/upload/cli/test_select.py
+++ b/test/upload/cli/test_select.py
@@ -1,13 +1,12 @@
 import os
 import sys
-import unittest
 import uuid
 from argparse import Namespace
 
 import six
-import tweak
 
 from ... import CapturingIO, reset_tweak_changes
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -16,9 +15,10 @@ import hca
 from hca.upload.cli.select_command import SelectCommand
 
 
-class TestUploadCliSelectCommand(unittest.TestCase):
+class TestUploadCliSelectCommand(UploadTestCase):
 
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)

--- a/test/upload/cli/test_select.py
+++ b/test/upload/cli/test_select.py
@@ -20,32 +20,33 @@ class TestUploadCliSelectCommand(UploadTestCase):
     def setUp(self):
         super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
-        creds = "foo"
-        self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
+        self.uri = "s3://org-humancellatlas-upload-test/{}/".format(self.area_uuid)
 
     def test_when_given_an_unrecognized_urn_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
         with CapturingIO('stdout') as stdout:
-            args = Namespace(urn_or_alias=self.urn)
+            args = Namespace(uri_or_alias=self.uri)
             SelectCommand(args)
 
         config = hca.get_config()
         self.assertIn(self.area_uuid, config.upload.areas)
-        self.assertEqual(self.urn, config.upload.areas[self.area_uuid])
+        self.assertEqual(self.uri, config.upload.areas[self.area_uuid]['uri'])
         self.assertEqual(self.area_uuid, config.upload.current_area)
 
-    def test_when_given_a_urn_it_prints_an_alias(self):
+    def test_when_given_a_uri_it_prints_an_alias(self):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                'deadbeef-dead-dead-dead-beeeeeeeeeef': 'dcp:upl:aws:dev:deadbeef-dead-dead-dead-beeeeeeeeeef:creds',
+                'deadbeef-dead-dead-dead-beeeeeeeeeef': {
+                    'uri': 's3://bogobucket/deadbeef-dead-dead-dead-beeeeeeeeeef/'
+                },
             }
         }
         config.save()
-        area_uuid = 'deafbeef-deaf-deaf-deaf-beeeeeeeeeef'
-        urn = 'dcp:upl:aws:dev:{}:creds'.format(area_uuid)
+        new_area_uuid = 'deafbeef-deaf-deaf-deaf-beeeeeeeeeef'
+        new_area_uri = 's3://bogobucket/{}/'.format(new_area_uuid)
 
         with CapturingIO('stdout') as stdout:
-            args = Namespace(urn_or_alias=urn)
+            args = Namespace(uri_or_alias=new_area_uri)
             SelectCommand(args)
 
         six.assertRegex(self, stdout.captured(), "alias \"{}\"".format('deaf'))
@@ -57,7 +58,7 @@ class TestUploadCliSelectCommand(UploadTestCase):
         config.save()
 
         with CapturingIO('stdout') as stdout:
-            args = Namespace(urn_or_alias='aaa')
+            args = Namespace(uri_or_alias='aaa')
             SelectCommand(args)
 
         six.assertRegex(self, stdout.captured(), "don't recognize area")
@@ -66,14 +67,14 @@ class TestUploadCliSelectCommand(UploadTestCase):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                'deadbeef-dead-dead-dead-beeeeeeeeeef': 'dcp:upl:aws:dev:deadbeef-dead-dead-dead-beeeeeeeeeef:creds',
-                'deafbeef-deaf-deaf-deaf-beeeeeeeeeef': 'dcp:upl:aws:dev:deafbeef-deaf-deaf-deaf-beeeeeeeeeef:creds',
+                'deadbeef-dead-dead-dead-beeeeeeeeeef': {'uri': 's3://bucket/deadbeef-dead-dead-dead-beeeeeeeeeef/'},
+                'deafbeef-deaf-deaf-deaf-beeeeeeeeeef': {'uri': 's3://bucket/deafbeef-deaf-deaf-deaf-beeeeeeeeeef/'},
             }
         }
         config.save()
 
         with CapturingIO('stdout') as stdout:
-            args = Namespace(urn_or_alias='dea')
+            args = Namespace(uri_or_alias='dea')
             SelectCommand(args)
 
         six.assertRegex(self, stdout.captured(), "matches more than one")
@@ -84,14 +85,14 @@ class TestUploadCliSelectCommand(UploadTestCase):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                a_uuid: "dcp:upl:aws:dev:%s" % (a_uuid,),
-                b_uuid: "dcp:upl:aws:dev:%s" % (b_uuid,),
+                a_uuid: {'uri': "s3://org-humancellatlas-upload-bogo/%s/" % (a_uuid,)},
+                b_uuid: {'uri': "s3://org-humancellatlas-upload-bogo/%s/" % (b_uuid,)},
             }
         }
         config.save()
 
         with CapturingIO('stdout') as stdout:
-            args = Namespace(urn_or_alias='bbb')
+            args = Namespace(uri_or_alias='bbb')
             SelectCommand(args)
 
         config = hca.get_config()

--- a/test/upload/cli/test_select.py
+++ b/test/upload/cli/test_select.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 
 import six
 
-from ... import CapturingIO, reset_tweak_changes
+from ... import CapturingIO
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -23,7 +23,6 @@ class TestUploadCliSelectCommand(UploadTestCase):
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
 
-    @reset_tweak_changes
     def test_when_given_an_unrecognized_urn_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
         with CapturingIO('stdout') as stdout:
             args = Namespace(urn_or_alias=self.urn)
@@ -34,7 +33,6 @@ class TestUploadCliSelectCommand(UploadTestCase):
         self.assertEqual(self.urn, config.upload.areas[self.area_uuid])
         self.assertEqual(self.area_uuid, config.upload.current_area)
 
-    @reset_tweak_changes
     def test_when_given_a_urn_it_prints_an_alias(self):
         config = hca.get_config()
         config.upload = {
@@ -52,7 +50,6 @@ class TestUploadCliSelectCommand(UploadTestCase):
 
         six.assertRegex(self, stdout.captured(), "alias \"{}\"".format('deaf'))
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_no_areas_it_prints_a_warning(self):
 
         config = hca.get_config()
@@ -65,7 +62,6 @@ class TestUploadCliSelectCommand(UploadTestCase):
 
         six.assertRegex(self, stdout.captured(), "don't recognize area")
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_more_than_one_area_it_prints_a_warning(self):
         config = hca.get_config()
         config.upload = {
@@ -82,7 +78,6 @@ class TestUploadCliSelectCommand(UploadTestCase):
 
         six.assertRegex(self, stdout.captured(), "matches more than one")
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_selects_it(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         b_uuid = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'

--- a/test/upload/cli/test_upload.py
+++ b/test/upload/cli/test_upload.py
@@ -1,12 +1,7 @@
-import base64
-import json
 import os
 import sys
-import uuid
 from argparse import Namespace
 from mock import patch, Mock
-
-import boto3
 
 from .. import UploadTestCase
 
@@ -14,23 +9,15 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) 
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca.upload.cli.upload_command import UploadCommand
-from .. import TEST_UPLOAD_BUCKET
 
 
 class TestUploadCliUploadCommand(UploadTestCase):
 
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.stage = os.environ['DEPLOYMENT_STAGE']
-        self.area_uuid = str(uuid.uuid4())
-        creds = {'AWS_ACCESS_KEY_ID': 'foo', 'AWS_SECRET_ACCESS_KEY': 'bar'}
-        encoded_creds = base64.b64encode(json.dumps(creds).encode('ascii')).decode('ascii')
-        self.urn = "dcp:upl:aws:{}:{}:{}".format(self.stage, self.area_uuid, encoded_creds)
+        self.area = self.mock_current_upload_area()
 
     def test_upload_with_target_filename_option(self):
-        s3 = boto3.resource('s3')
-        s3.Bucket(TEST_UPLOAD_BUCKET).create()
-
         args = Namespace(
             file_paths=['test/bundle/sample.json'],
             target_filename='FOO',
@@ -38,20 +25,17 @@ class TestUploadCliUploadCommand(UploadTestCase):
             quiet=True)
         UploadCommand(args)
 
-        obj = s3.Bucket(TEST_UPLOAD_BUCKET).Object("{}/FOO".format(self.area_uuid))
+        obj = self.upload_bucket.Object("{}/FOO".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/json; dcp-type=data')
         with open('test/bundle/sample.json', 'rb') as fh:
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
     def test_upload_with_dcp_type_option(self):
-        s3 = boto3.resource('s3')
-        s3.Bucket(TEST_UPLOAD_BUCKET).create()
-
         args = Namespace(file_paths=['LICENSE'], target_filename=None, no_transfer_acceleration=False, quiet=True)
         UploadCommand(args)
 
-        obj = s3.Bucket(TEST_UPLOAD_BUCKET).Object("{}/LICENSE".format(self.area_uuid))
+        obj = self.upload_bucket.Object("{}/LICENSE".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/octet-stream; dcp-type=data')
         with open('LICENSE', 'rb') as fh:
             expected_contents = fh.read()
@@ -74,16 +58,13 @@ class TestUploadCliUploadCommand(UploadTestCase):
             mock_config.assert_called_once_with()
 
     def test_multiple_uploads(self):
-        s3 = boto3.resource('s3')
-        s3.Bucket(TEST_UPLOAD_BUCKET).create()
-
         files = ['LICENSE', 'README.rst']
         args = Namespace(file_paths=files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True)
         UploadCommand(args)
 
         for filename in files:
-            obj = s3.Bucket(TEST_UPLOAD_BUCKET).Object("{}/{}".format(self.area_uuid, filename))
+            obj = self.upload_bucket.Object("{}/{}".format(self.area.uuid, filename))
             with open(filename, 'rb') as fh:
                 expected_contents = fh.read()
                 self.assertEqual(obj.get()['Body'].read(), expected_contents)

--- a/test/upload/cli/test_upload.py
+++ b/test/upload/cli/test_upload.py
@@ -3,6 +3,8 @@ import sys
 from argparse import Namespace
 from mock import patch, Mock
 
+import responses
+
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -17,12 +19,17 @@ class TestUploadCliUploadCommand(UploadTestCase):
         super(self.__class__, self).setUp()
         self.area = self.mock_current_upload_area()
 
+    @responses.activate
     def test_upload_with_target_filename_option(self):
+
         args = Namespace(
             file_paths=['test/bundle/sample.json'],
             target_filename='FOO',
             no_transfer_acceleration=False,
             quiet=True)
+
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+
         UploadCommand(args)
 
         obj = self.upload_bucket.Object("{}/FOO".format(self.area.uuid))
@@ -31,8 +38,13 @@ class TestUploadCliUploadCommand(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
+    @responses.activate
     def test_upload_with_dcp_type_option(self):
+
         args = Namespace(file_paths=['LICENSE'], target_filename=None, no_transfer_acceleration=False, quiet=True)
+
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+
         UploadCommand(args)
 
         obj = self.upload_bucket.Object("{}/LICENSE".format(self.area.uuid))
@@ -41,6 +53,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
+    @responses.activate
     @patch('hca.upload.s3_agent.S3Agent.upload_file')   # Don't actually try to upload
     def test_no_transfer_acceleration_option_sets_up_botocore_config_correctly(self, upload_file_stub):
         import botocore
@@ -49,6 +62,9 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
             args = Namespace(file_paths=['LICENSE'], target_filename=None, quiet=True)
             args.no_transfer_acceleration = False
+
+            self.simulate_credentials_api(area_uuid=self.area.uuid)
+
             UploadCommand(args)
             mock_config.assert_called_once_with(s3={'use_accelerate_endpoint': True})
 
@@ -57,10 +73,15 @@ class TestUploadCliUploadCommand(UploadTestCase):
             UploadCommand(args)
             mock_config.assert_called_once_with()
 
+    @responses.activate
     def test_multiple_uploads(self):
+
         files = ['LICENSE', 'README.rst']
         args = Namespace(file_paths=files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True)
+
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+
         UploadCommand(args)
 
         for filename in files:

--- a/test/upload/cli/test_upload.py
+++ b/test/upload/cli/test_upload.py
@@ -2,15 +2,14 @@ import base64
 import json
 import os
 import sys
-import unittest
 import uuid
 from argparse import Namespace
 from mock import patch, Mock
 
 import boto3
-from moto import mock_s3
 
 from ... import reset_tweak_changes
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -20,9 +19,10 @@ from hca.upload.cli.upload_command import UploadCommand
 from .. import UPLOAD_BUCKET_NAME_TEMPLATE, TEST_UPLOAD_BUCKET
 
 
-class TestUploadCliUploadCommand(unittest.TestCase):
+class TestUploadCliUploadCommand(UploadTestCase):
 
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.stage = os.environ['DEPLOYMENT_STAGE']
         self.area_uuid = str(uuid.uuid4())
         creds = {'AWS_ACCESS_KEY_ID': 'foo', 'AWS_SECRET_ACCESS_KEY': 'bar'}
@@ -38,7 +38,6 @@ class TestUploadCliUploadCommand(unittest.TestCase):
         }
         config.save()
 
-    @mock_s3
     @reset_tweak_changes
     def test_upload_with_target_filename_option(self):
         self.setup_tweak_config()
@@ -58,7 +57,6 @@ class TestUploadCliUploadCommand(unittest.TestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @mock_s3
     @reset_tweak_changes
     def test_upload_with_dcp_type_option(self):
         self.setup_tweak_config()
@@ -74,7 +72,6 @@ class TestUploadCliUploadCommand(unittest.TestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @mock_s3
     @reset_tweak_changes
     @patch('hca.upload.s3_agent.S3Agent.upload_file')   # Don't actually try to upload
     def test_no_transfer_acceleration_option_sets_up_botocore_config_correctly(self, upload_file_stub):
@@ -93,7 +90,6 @@ class TestUploadCliUploadCommand(unittest.TestCase):
             UploadCommand(args)
             mock_config.assert_called_once_with()
 
-    @mock_s3
     @reset_tweak_changes
     def test_multiple_uploads(self):
         self.setup_tweak_config()

--- a/test/upload/cli/test_upload.py
+++ b/test/upload/cli/test_upload.py
@@ -8,7 +8,6 @@ from mock import patch, Mock
 
 import boto3
 
-from ... import reset_tweak_changes
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -38,7 +37,6 @@ class TestUploadCliUploadCommand(UploadTestCase):
         }
         config.save()
 
-    @reset_tweak_changes
     def test_upload_with_target_filename_option(self):
         self.setup_tweak_config()
         s3 = boto3.resource('s3')
@@ -57,7 +55,6 @@ class TestUploadCliUploadCommand(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @reset_tweak_changes
     def test_upload_with_dcp_type_option(self):
         self.setup_tweak_config()
         s3 = boto3.resource('s3')
@@ -72,7 +69,6 @@ class TestUploadCliUploadCommand(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @reset_tweak_changes
     @patch('hca.upload.s3_agent.S3Agent.upload_file')   # Don't actually try to upload
     def test_no_transfer_acceleration_option_sets_up_botocore_config_correctly(self, upload_file_stub):
         self.setup_tweak_config()
@@ -90,7 +86,6 @@ class TestUploadCliUploadCommand(UploadTestCase):
             UploadCommand(args)
             mock_config.assert_called_once_with()
 
-    @reset_tweak_changes
     def test_multiple_uploads(self):
         self.setup_tweak_config()
         s3 = boto3.resource('s3')

--- a/test/upload/python_bindings/test_forget_area.py
+++ b/test/upload/python_bindings/test_forget_area.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from .. import UploadTestCase, mock_upload_area, mock_current_upload_area
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -12,7 +12,7 @@ from hca.upload import UploadConfig, UploadException, forget_area
 class TestUploadForget(UploadTestCase):
 
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
-        area = mock_current_upload_area()
+        area = self.mock_current_upload_area()
         self.assertIn(area.uuid, UploadConfig().areas)
         self.assertEqual(area.uuid, UploadConfig().current_area)
 
@@ -27,8 +27,8 @@ class TestUploadForget(UploadTestCase):
             forget_area('bogo-uuid')
 
     def test_when_given_an_alias_that_matches_more_than_one_area_it_raises(self):
-        mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
-        mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')
+        self.mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
+        self.mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')
 
         with self.assertRaises(UploadException):
             forget_area('dea')

--- a/test/upload/python_bindings/test_forget_area.py
+++ b/test/upload/python_bindings/test_forget_area.py
@@ -16,12 +16,12 @@ class TestUploadForget(unittest.TestCase):
     @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
         area = mock_current_upload_area()
-        self.assertIn(area.uuid, UploadConfig().areas())
+        self.assertIn(area.uuid, UploadConfig().areas)
         self.assertEqual(area.uuid, UploadConfig().current_area)
 
         forget_area(area.uuid)
 
-        self.assertNotIn(area.uuid, UploadConfig().areas())
+        self.assertNotIn(area.uuid, UploadConfig().areas)
         self.assertEqual(None, UploadConfig().current_area)
 
     @reset_tweak_changes

--- a/test/upload/python_bindings/test_forget_area.py
+++ b/test/upload/python_bindings/test_forget_area.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from ... import reset_tweak_changes
 from .. import UploadTestCase, mock_upload_area, mock_current_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -12,7 +11,6 @@ from hca.upload import UploadConfig, UploadException, forget_area
 
 class TestUploadForget(UploadTestCase):
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):
         area = mock_current_upload_area()
         self.assertIn(area.uuid, UploadConfig().areas)
@@ -23,13 +21,11 @@ class TestUploadForget(UploadTestCase):
         self.assertNotIn(area.uuid, UploadConfig().areas)
         self.assertEqual(None, UploadConfig().current_area)
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_no_areas_it_raises(self):
 
         with self.assertRaises(UploadException):
             forget_area('bogo-uuid')
 
-    @reset_tweak_changes
     def test_when_given_an_alias_that_matches_more_than_one_area_it_raises(self):
         mock_upload_area('deadbeef-dead-dead-dead-beeeeeeeeeef')
         mock_upload_area('deafbeef-deaf-deaf-deaf-beeeeeeeeeef')

--- a/test/upload/python_bindings/test_forget_area.py
+++ b/test/upload/python_bindings/test_forget_area.py
@@ -1,9 +1,8 @@
 import os
 import sys
-import unittest
 
 from ... import reset_tweak_changes
-from .. import mock_upload_area, mock_current_upload_area
+from .. import UploadTestCase, mock_upload_area, mock_current_upload_area
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -11,7 +10,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from hca.upload import UploadConfig, UploadException, forget_area
 
 
-class TestUploadForget(unittest.TestCase):
+class TestUploadForget(UploadTestCase):
 
     @reset_tweak_changes
     def test_when_given_an_alias_that_matches_one_area_it_forgets_that_area(self):

--- a/test/upload/python_bindings/test_get_credentials.py
+++ b/test/upload/python_bindings/test_get_credentials.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import responses
+
+from .. import UploadTestCase
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from hca import upload
+
+
+class TestGetCredentials(UploadTestCase):
+
+    def test_get_credentials(self):
+
+        area = self.mock_current_upload_area()
+
+        creds_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/credentials'.format(
+            stage=self.deployment_stage, uuid=area.uuid)
+
+        responses.add(responses.POST, creds_url,
+                      json={'AccessKeyId': 'foo', 'SecretAccessKey': 'bar', 'SessionToken': 'baz'},
+                      status=201)
+
+        upload.get_credentials(area.uuid)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, creds_url)

--- a/test/upload/python_bindings/test_list_area.py
+++ b/test/upload/python_bindings/test_list_area.py
@@ -4,8 +4,6 @@ import sys
 import boto3
 import responses
 
-from ... import reset_tweak_changes
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -22,7 +20,6 @@ class TestUploadListArea(UploadTestCase):
         self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
         self.upload_bucket.create()
 
-    @reset_tweak_changes
     def test_list_current_area(self):
         area = mock_current_upload_area()
         self.upload_bucket.Object('/'.join([area.uuid, 'bogofile'])).put(Body="foo")
@@ -31,7 +28,6 @@ class TestUploadListArea(UploadTestCase):
 
         self.assertEqual(file_list, [{'name': 'bogofile'}])
 
-    @reset_tweak_changes
     @responses.activate
     def test_list_current_area_with_detail(self):
         area = mock_current_upload_area()

--- a/test/upload/python_bindings/test_list_area.py
+++ b/test/upload/python_bindings/test_list_area.py
@@ -1,41 +1,32 @@
 import os
 import sys
 
-import boto3
 import responses
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca import upload
-from .. import UploadTestCase, mock_current_upload_area
+from .. import UploadTestCase
 
 
 class TestUploadListArea(UploadTestCase):
 
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.deployment_stage = 'test'
-        self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
-        self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
-        self.upload_bucket.create()
+        self.area = self.mock_current_upload_area()
+        self.upload_bucket.Object('/'.join([self.area.uuid, 'bogofile'])).put(Body="foo")
 
     def test_list_current_area(self):
-        area = mock_current_upload_area()
-        self.upload_bucket.Object('/'.join([area.uuid, 'bogofile'])).put(Body="foo")
-
         file_list = list(upload.list_current_area())
 
         self.assertEqual(file_list, [{'name': 'bogofile'}])
 
     @responses.activate
     def test_list_current_area_with_detail(self):
-        area = mock_current_upload_area()
-        self.upload_bucket.Object('/'.join([area.uuid, 'bogofile'])).put(Body="foo")
-
         list_url = 'https://upload.{stage}.data.humancellatlas.org/v1/area/{uuid}/files_info'.format(
             stage=self.deployment_stage,
-            uuid=area.uuid)
+            uuid=self.area.uuid)
         responses.add(responses.PUT, list_url, json=[{"name": "bogofile", "size": 1234}], status=200)
 
         file_list = list(upload.list_current_area(detail=True))

--- a/test/upload/python_bindings/test_list_area.py
+++ b/test/upload/python_bindings/test_list_area.py
@@ -1,9 +1,7 @@
 import os
 import sys
-import unittest
 
 import boto3
-from moto import mock_s3
 import responses
 
 from ... import reset_tweak_changes
@@ -12,22 +10,17 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) 
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca import upload
-from .. import mock_current_upload_area
+from .. import UploadTestCase, mock_current_upload_area
 
 
-class TestUploadListArea(unittest.TestCase):
+class TestUploadListArea(UploadTestCase):
 
     def setUp(self):
-        self.s3_mock = mock_s3()
-        self.s3_mock.start()
-
+        super(self.__class__, self).setUp()
         self.deployment_stage = 'test'
         self.upload_bucket_name = 'org-humancellatlas-upload-{}'.format(self.deployment_stage)
         self.upload_bucket = boto3.resource('s3').Bucket(self.upload_bucket_name)
         self.upload_bucket.create()
-
-    def tearDown(self):
-        self.s3_mock.stop()
 
     @reset_tweak_changes
     def test_list_current_area(self):

--- a/test/upload/python_bindings/test_list_areas.py
+++ b/test/upload/python_bindings/test_list_areas.py
@@ -21,8 +21,8 @@ class TestUploadListAreas(UploadTestCase):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                a_uuid: "dcp:upl:aws:dev:%s" % (a_uuid,),
-                b_uuid: "dcp:upl:aws:dev:%s" % (b_uuid,),
+                a_uuid: {'uri': "s3://foo/{}/".format(a_uuid)},
+                b_uuid: {'uri': "s3://foo/{}/".format(b_uuid)},
             },
             'current_area': a_uuid
         }

--- a/test/upload/python_bindings/test_list_areas.py
+++ b/test/upload/python_bindings/test_list_areas.py
@@ -1,11 +1,7 @@
 import os
 import sys
-import unittest
 import uuid
 
-import tweak
-
-from ... import reset_tweak_changes
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -23,7 +19,6 @@ class TestUploadListAreas(UploadTestCase):
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
 
-    @reset_tweak_changes
     def test_list_areas_lists_areas_when_there_are_some(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         b_uuid = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
@@ -45,7 +40,6 @@ class TestUploadListAreas(UploadTestCase):
             {'uuid': b_uuid, 'is_selected': False}
         ])
 
-    @reset_tweak_changes
     def test_list_areas_doesnt_error_when_the_upload_tweak_config_is_not_setup(self):
         config = hca.get_config()
         if 'upload' in config:

--- a/test/upload/python_bindings/test_list_areas.py
+++ b/test/upload/python_bindings/test_list_areas.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import uuid
 
 from .. import UploadTestCase
 
@@ -15,9 +14,6 @@ class TestUploadListAreas(UploadTestCase):
 
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.area_uuid = str(uuid.uuid4())
-        creds = "foo"
-        self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
 
     def test_list_areas_lists_areas_when_there_are_some(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'

--- a/test/upload/python_bindings/test_list_areas.py
+++ b/test/upload/python_bindings/test_list_areas.py
@@ -6,6 +6,7 @@ import uuid
 import tweak
 
 from ... import reset_tweak_changes
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -14,9 +15,10 @@ import hca
 from hca import upload
 
 
-class TestUploadListAreas(unittest.TestCase):
+class TestUploadListAreas(UploadTestCase):
 
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)

--- a/test/upload/python_bindings/test_select_area.py
+++ b/test/upload/python_bindings/test_select_area.py
@@ -2,7 +2,6 @@ import os
 import sys
 import uuid
 
-from ... import reset_tweak_changes
 from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -21,13 +20,11 @@ class TestUploadSelectArea(UploadTestCase):
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
 
-    @reset_tweak_changes
     def test_when_given_neither_a_uuid_or_urn_it_raises(self):
 
         with self.assertRaises(UploadException):
             upload.select_area()
 
-    @reset_tweak_changes
     def test_when_given_an_unrecognized_urn_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
         upload.select_area(urn=self.urn)
 
@@ -36,7 +33,6 @@ class TestUploadSelectArea(UploadTestCase):
         self.assertEqual(self.urn, config.upload.areas[self.area_uuid])
         self.assertEqual(self.area_uuid, config.upload.current_area)
 
-    @reset_tweak_changes
     def test_when_given_a_uuid_of_an_existing_area_it_selects_that_area(self):
         a_uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         b_uuid = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
@@ -54,7 +50,6 @@ class TestUploadSelectArea(UploadTestCase):
         config = hca.get_config()
         self.assertEqual(b_uuid, config.upload.current_area)
 
-    @reset_tweak_changes
     def test_when_given_a_uuid_of_an_unknown_area_it_raises_an_error(self):
 
         with self.assertRaises(UploadException):

--- a/test/upload/python_bindings/test_select_area.py
+++ b/test/upload/python_bindings/test_select_area.py
@@ -17,20 +17,19 @@ class TestUploadSelectArea(UploadTestCase):
     def setUp(self):
         super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
-        creds = "foo"
-        self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)
+        self.uri = "s3://org-humancellatlas-upload-test/{}/".format(self.area_uuid)
 
-    def test_when_given_neither_a_uuid_or_urn_it_raises(self):
+    def test_when_given_neither_a_uuid_or_uri_it_raises(self):
 
         with self.assertRaises(UploadException):
             upload.select_area()
 
-    def test_when_given_an_unrecognized_urn_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
-        upload.select_area(urn=self.urn)
+    def test_when_given_an_unrecognized_uri_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
+        upload.select_area(uri=self.uri)
 
         config = hca.get_config()
         self.assertIn(self.area_uuid, config.upload.areas)
-        self.assertEqual(self.urn, config.upload.areas[self.area_uuid])
+        self.assertEqual(self.uri, config.upload.areas[self.area_uuid]['uri'])
         self.assertEqual(self.area_uuid, config.upload.current_area)
 
     def test_when_given_a_uuid_of_an_existing_area_it_selects_that_area(self):
@@ -39,9 +38,9 @@ class TestUploadSelectArea(UploadTestCase):
         config = hca.get_config()
         config.upload = {
             'areas': {
-                a_uuid: "dcp:upl:aws:dev:%s" % (a_uuid,),
-                b_uuid: "dcp:upl:aws:dev:%s" % (b_uuid,),
-            }
+                a_uuid: {'uri': "s3://foo/{}/".format(a_uuid)},
+                b_uuid: {'uri': "s3://foo/{}/".format(b_uuid)},
+            },
         }
         config.save()
 

--- a/test/upload/python_bindings/test_select_area.py
+++ b/test/upload/python_bindings/test_select_area.py
@@ -1,11 +1,9 @@
 import os
 import sys
-import unittest
 import uuid
 
-import tweak
-
 from ... import reset_tweak_changes
+from .. import UploadTestCase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -15,9 +13,10 @@ from hca import upload
 from hca.upload.exceptions import UploadException
 
 
-class TestUploadSelectArea(unittest.TestCase):
+class TestUploadSelectArea(UploadTestCase):
 
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.area_uuid = str(uuid.uuid4())
         creds = "foo"
         self.urn = "dcp:upl:aws:dev:{}:{}".format(self.area_uuid, creds)

--- a/test/upload/python_bindings/test_upload_file.py
+++ b/test/upload/python_bindings/test_upload_file.py
@@ -7,13 +7,12 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) 
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca import upload
-from .. import UploadTestCase, TEST_UPLOAD_BUCKET, mock_current_upload_area, setup_tweak_config
+from .. import UploadTestCase, TEST_UPLOAD_BUCKET, mock_current_upload_area
 
 
 class TestUploadFileUpload(UploadTestCase):
 
     def test_file_upload(self):
-        setup_tweak_config()
         area = mock_current_upload_area()
         s3 = boto3.resource('s3')
         s3.Bucket(TEST_UPLOAD_BUCKET).create()
@@ -28,7 +27,6 @@ class TestUploadFileUpload(UploadTestCase):
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
     def test_file_upload_with_target_filename_option(self):
-        setup_tweak_config()
         area = mock_current_upload_area()
         s3 = boto3.resource('s3')
         s3.Bucket(TEST_UPLOAD_BUCKET).create()

--- a/test/upload/python_bindings/test_upload_file.py
+++ b/test/upload/python_bindings/test_upload_file.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import responses
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -14,7 +16,10 @@ class TestUploadFileUpload(UploadTestCase):
         super(self.__class__, self).setUp()
         self.area = self.mock_current_upload_area()
 
+    @responses.activate
     def test_file_upload(self):
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+
         file_path = os.path.join(os.path.dirname(__file__), '..', '..', 'bundle', 'assay.json')
         upload.upload_file(file_path)
 
@@ -24,7 +29,10 @@ class TestUploadFileUpload(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
+    @responses.activate
     def test_file_upload_with_target_filename_option(self):
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+
         upload.upload_file('LICENSE', target_filename='POO')
 
         obj = self.upload_bucket.Object("{}/POO".format(self.area.uuid))

--- a/test/upload/python_bindings/test_upload_file.py
+++ b/test/upload/python_bindings/test_upload_file.py
@@ -1,39 +1,33 @@
 import os
 import sys
 
-import boto3
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca import upload
-from .. import UploadTestCase, TEST_UPLOAD_BUCKET, mock_current_upload_area
+from .. import UploadTestCase
 
 
 class TestUploadFileUpload(UploadTestCase):
 
-    def test_file_upload(self):
-        area = mock_current_upload_area()
-        s3 = boto3.resource('s3')
-        s3.Bucket(TEST_UPLOAD_BUCKET).create()
+    def setUp(self):
+        super(self.__class__, self).setUp()
+        self.area = self.mock_current_upload_area()
 
+    def test_file_upload(self):
         file_path = os.path.join(os.path.dirname(__file__), '..', '..', 'bundle', 'assay.json')
         upload.upload_file(file_path)
 
-        obj = s3.Bucket(TEST_UPLOAD_BUCKET).Object("{}/assay.json".format(area.uuid))
+        obj = self.upload_bucket.Object("{}/assay.json".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/json; dcp-type=data')
         with open(file_path, 'rb') as fh:
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
     def test_file_upload_with_target_filename_option(self):
-        area = mock_current_upload_area()
-        s3 = boto3.resource('s3')
-        s3.Bucket(TEST_UPLOAD_BUCKET).create()
-
         upload.upload_file('LICENSE', target_filename='POO')
 
-        obj = s3.Bucket(TEST_UPLOAD_BUCKET).Object("{}/POO".format(area.uuid))
+        obj = self.upload_bucket.Object("{}/POO".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/octet-stream; dcp-type=data')
         with open('LICENSE', 'rb') as fh:
             expected_contents = fh.read()

--- a/test/upload/python_bindings/test_upload_file.py
+++ b/test/upload/python_bindings/test_upload_file.py
@@ -3,8 +3,6 @@ import sys
 
 import boto3
 
-from ... import reset_tweak_changes
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -14,7 +12,6 @@ from .. import UploadTestCase, TEST_UPLOAD_BUCKET, mock_current_upload_area, set
 
 class TestUploadFileUpload(UploadTestCase):
 
-    @reset_tweak_changes
     def test_file_upload(self):
         setup_tweak_config()
         area = mock_current_upload_area()
@@ -30,7 +27,6 @@ class TestUploadFileUpload(UploadTestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @reset_tweak_changes
     def test_file_upload_with_target_filename_option(self):
         setup_tweak_config()
         area = mock_current_upload_area()

--- a/test/upload/python_bindings/test_upload_file.py
+++ b/test/upload/python_bindings/test_upload_file.py
@@ -1,9 +1,7 @@
 import os
 import sys
-import unittest
 
 import boto3
-from moto import mock_s3
 
 from ... import reset_tweak_changes
 
@@ -11,12 +9,11 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) 
 sys.path.insert(0, pkg_root)  # noqa
 
 from hca import upload
-from .. import TEST_UPLOAD_BUCKET, mock_current_upload_area, setup_tweak_config
+from .. import UploadTestCase, TEST_UPLOAD_BUCKET, mock_current_upload_area, setup_tweak_config
 
 
-class TestUploadFileUpload(unittest.TestCase):
+class TestUploadFileUpload(UploadTestCase):
 
-    @mock_s3
     @reset_tweak_changes
     def test_file_upload(self):
         setup_tweak_config()
@@ -33,7 +30,6 @@ class TestUploadFileUpload(unittest.TestCase):
             expected_contents = fh.read()
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
-    @mock_s3
     @reset_tweak_changes
     def test_file_upload_with_target_filename_option(self):
         setup_tweak_config()

--- a/test/upload/test_credentials_manager.py
+++ b/test/upload/test_credentials_manager.py
@@ -1,0 +1,79 @@
+import responses
+from mock import patch
+
+from . import UploadTestCase
+
+from hca.upload import UploadConfig
+from hca.upload.credentials_manager import CredentialsManager
+
+call_count = 0
+
+
+class TestCredentialsManager(UploadTestCase):
+
+    def setUp(self):
+        super(self.__class__, self).setUp()
+        self.area = self.mock_current_upload_area()
+        self.cm = CredentialsManager(upload_area=self.area)
+
+    def _store_credentials(self):
+        stored_creds = {'aws_access_key_id': 'skey', 'aws_secret_access_key': 'ssecret', 'aws_session_token': 'stoken'}
+        config = UploadConfig()
+        config.areas[self.area.uuid]['credentials'] = stored_creds
+        config.save()
+        return stored_creds
+
+    def _simulate_credentials_api(self):
+        api_host = "upload.{stage}.data.humancellatlas.org".format(stage=self.area.deployment_stage)
+        creds_url = 'https://{api_host}/v1/area/{uuid}/credentials'.format(api_host=api_host, uuid=self.area.uuid)
+        api_creds = {'AccessKeyId': 'apikey', 'SecretAccessKey': 'apisecret', 'SessionToken': 'apitoken'}
+        responses.add(responses.POST, creds_url, json=api_creds, status=201)
+        expected_creds = {
+            'aws_access_key_id': api_creds['AccessKeyId'],
+            'aws_secret_access_key': api_creds['SecretAccessKey'],
+            'aws_session_token': api_creds['SessionToken']
+        }
+        return (creds_url, expected_creds)
+
+    @responses.activate
+    def test_get_credentials_with_no_creds_in_config_should_get_them_from_the_api_and_save_then_in_config(self):
+        creds_url, expected_creds = self._simulate_credentials_api()
+
+        creds = self.cm.get_credentials()
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, creds_url)
+        self.assertEqual(expected_creds, creds)
+        self.assertEqual(expected_creds, UploadConfig().areas[self.area.uuid]['credentials'])
+
+    @responses.activate
+    def test_get_credentials_with_good_creds_in_config_it_should_return_them_and_not_call_the_api(self):
+        self._simulate_credentials_api()
+        stored_creds = self._store_credentials()
+
+        creds = self.cm.get_credentials()
+
+        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(stored_creds, creds)
+
+    @responses.activate
+    @patch('hca.upload.credentials_manager.CredentialsManager._credentials_are_good')
+    def test_get_credentials_with_bad_creds_in_config_it_should_get_new_ones_from_the_api(self, mock_creds_good):
+        mock_creds_good.return_value = False
+        creds_url, expected_creds = self._simulate_credentials_api()
+        self._store_credentials()
+
+        creds = self.cm.get_credentials()
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, creds_url)
+        self.assertEqual(expected_creds, creds)
+        self.assertEqual(expected_creds, UploadConfig().areas[self.area.uuid]['credentials'])
+
+    def test_delete_credentials_for_area(self):
+        self._store_credentials()
+
+        self.cm.delete_credentials()
+
+        config = UploadConfig()
+        self.assertNotIn('credentials', config.areas[self.area.uuid])


### PR DESCRIPTION
instead of using IAM user for each upload area

Described in document: https://docs.google.com/document/d/1JFO75A9OR1gnCT1nYHH5p-vEaf0-TdOtOme3M3b9g3A/edit#

Paired with https://github.com/HumanCellAtlas/upload-service/pull/100