### PR TITLE
Adjust default client timeouts

### DIFF
--- a/test/test_dss_api_retry.py
+++ b/test/test_dss_api_retry.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
 # coding: utf-8
-
 import io
 import os
+import socket
 import sys
 import tempfile
 import unittest
 import uuid
+
+from requests import ConnectTimeout
+from urllib3 import Timeout
+
+from hca.util import RetryPolicy
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -18,8 +23,10 @@ from hca.dss import upload_to_cloud
 if USING_PYTHON2:
     import backports.tempfile
     TemporaryDirectory = backports.tempfile.TemporaryDirectory
+    import mock
 else:
     TemporaryDirectory = tempfile.TemporaryDirectory
+    from unittest import mock
 
 
 class TestDssApiRetry(unittest.TestCase):
@@ -72,6 +79,26 @@ class TestDssApiRetry(unittest.TestCase):
                 'DSS_FAKE_504_PROBABILITY': "0.5",
             },
         )
+
+    def test_timeouts(self):
+        # This doesn't cover the read timeout because that is harder to mock without adversely affecting the
+        # environment we're running in, but if we observe that the `requests` library correctly applies the
+        # connection timeout we can safely assume that would also apply the read timeout.
+        client = hca.dss.DSSClient()
+        client.timeout_policy = Timeout(connect=.123, read=.234)
+        # Prevent unnecessary retries on socket.connect() that don't contribute to code coverage
+        client.retry_policy = RetryPolicy(connect=0)
+        with mock.patch('socket.socket.settimeout') as mock_settimeout:
+            with mock.patch('socket.socket.connect') as mock_connect:
+                mock_connect.side_effect = socket.timeout
+                self.assertRaises(ConnectTimeout, client.get_bundle, uuid=str(uuid.uuid4()), replica='gcp')
+            settimeout_calls, connect_calls = mock_settimeout.mock_calls, mock_connect.mock_calls
+            # If a domain name resolves to more than one IP (multiple A records with the same name), urllib3 will
+            # try each one in turn. That's why we may observe multiple calls to settimeout() and connect(). But they
+            # should come in pairs. We don't care what connect() was called with, only settimout().
+            self.assertEquals(len(settimeout_calls), len(connect_calls))
+            self.assertEquals(settimeout_calls, [mock.call(.123)] * len(settimeout_calls))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Additionally, hang timeout config off of client instead of method
factory so user's can more easily modify the default timeouts.

See added test for how to do that.