### PR TITLE
Refetch DSS API definition weekly (#79)

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -241,7 +241,7 @@ class SwaggerClient(object):
                 swagger_filename = os.path.join(self.config.user_config_dir, swagger_filename)
             is_cached = os.path.exists(swagger_filename)
             if (not is_cached) or (is_cached and
-                                 self._get_days_since_last_modified(swagger_filename) >= self._spec_valid_for_days):
+                                   self._get_days_since_last_modified(swagger_filename) >= self._spec_valid_for_days):
                 try:
                     os.makedirs(self.config.user_config_dir)
                 except OSError as e:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -83,7 +83,7 @@ client. Subclasses can add more commands by adding them to the
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os, datetime, types, collections, typing, json, errno, base64, argparse
+import os, types, collections, typing, json, errno, base64, argparse
 
 try:
     from inspect import signature, Signature, Parameter
@@ -95,6 +95,7 @@ from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
 from urllib3.util import retry, timeout
 from jsonpointer import resolve_pointer
+from datetime import datetime
 
 from .. import get_config, logger
 from .compat import USING_PYTHON2
@@ -302,8 +303,8 @@ class SwaggerClient(object):
         print("Storing access credentials")
 
     def _get_days_since_last_modified(self, filename):
-        now = datetime.datetime.now()
-        last_modified = datetime.datetime.fromtimestamp(os.path.getmtime(filename))
+        now = datetime.now()
+        last_modified = datetime.fromtimestamp(os.path.getmtime(filename))
         return (now - last_modified).days
 
     def _get_oauth_token_from_service_account_credentials(self):

--- a/test/test_dss_api_retry.py
+++ b/test/test_dss_api_retry.py
@@ -10,6 +10,7 @@ import uuid
 
 from requests import ConnectTimeout
 from urllib3 import Timeout
+from datetime import datetime
 
 from hca.util import RetryPolicy
 
@@ -61,10 +62,12 @@ class TestDssApiRetry(unittest.TestCase):
         client = hca.dss.DSSClient()
         file_uuid = str(uuid.uuid4())
         creator_uid = client.config.get("creator_uid", 0)
+        version = datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ")
 
         client.put_file._request(
             dict(
                 uuid=file_uuid,
+                version=version,
                 bundle_uuid=str(uuid.uuid4()),
                 creator_uid=creator_uid,
                 source_url=TestDssApiRetry.source_url,

--- a/test/test_dss_swagger_spec.py
+++ b/test/test_dss_swagger_spec.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import unittest
+import requests
+from hca.util.compat import USING_PYTHON2
+
+import hca.dss
+
+if USING_PYTHON2:
+    import mock
+    from mock import mock_open
+else:
+    from unittest import mock
+    from unittest.mock import mock_open
+
+
+class TestDssSwaggerSpec(unittest.TestCase):
+    client = hca.dss.DSSClient()
+    swagger_url = ""
+    dummy_response = None
+    open_fn_name = "__builtin__.open" if USING_PYTHON2 else "builtins.open"
+
+    def setUp(self):
+        self.client._swagger_spec = None
+        self.client._spec_valid_for_days = 1
+        self.swagger_url = "test_swagger_url"
+        self.client._session = requests.Session()
+        self.client.config.__dict__.update({
+            'DSSClient': {
+                'swagger_url': self.swagger_url
+            },
+            'swagger_filename': "test_filename"
+        })
+        self.dummy_response = requests.models.Response()
+        self.dummy_response._content = b'{"swagger": ""}'
+        self.dummy_response.status_code = 200
+
+    def test_get_swagger_spec_new(self):
+        with mock.patch('os.path.exists') as mock_exists, \
+             mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
+             mock.patch('os.makedirs') as mock_makedirs, \
+             mock.patch('requests.Session.get') as mock_get, \
+             mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
+             mock.patch(self.open_fn_name, mock_open()) as open_mock:
+                mock_exists.return_value = False
+                mock_days_since_last_modified.return_value = 0
+                mock_get.return_value = self.dummy_response
+
+                test = self.client.swagger_spec
+                self.assertTrue(mock_makedirs.called)
+                self.assertTrue(mock_get.calledWith(self.swagger_url))
+                self.assertTrue(open_mock().write.calledWith(self.dummy_response._content))
+
+    def test_get_swagger_spec_cache_valid(self):
+        with mock.patch('os.path.exists') as mock_exists, \
+                mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
+                mock.patch('os.makedirs') as mock_makedirs, \
+                mock.patch('requests.Session.get') as mock_get, \
+                mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
+                mock.patch(self.open_fn_name, mock_open()) as open_mock:
+                    mock_exists.return_value = True
+                    mock_days_since_last_modified.return_value = 0
+                    mock_get.return_value = self.dummy_response
+
+                    test = self.client.swagger_spec
+                    self.assertFalse(mock_makedirs.called)
+                    self.assertFalse(mock_get.called)
+                    self.assertFalse(open_mock().write.called)
+
+    def test_get_swagger_spec_cache_expired(self):
+        with mock.patch('os.path.exists') as mock_exists, \
+                mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
+                mock.patch('os.makedirs') as mock_makedirs, \
+                mock.patch('requests.Session.get') as mock_get, \
+                mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
+                mock.patch(self.open_fn_name, mock_open()) as open_mock:
+                    mock_exists.return_value = True
+                    mock_days_since_last_modified.return_value = 2
+                    mock_get.return_value = self.dummy_response
+
+                    test = self.client.swagger_spec
+                    self.assertTrue(mock_get.calledWith(self.swagger_url))
+                    self.assertTrue(open_mock().write.calledWith(self.dummy_response._content))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_dss_swagger_spec.py
+++ b/test/test_dss_swagger_spec.py
@@ -22,7 +22,7 @@ class TestDssSwaggerSpec(unittest.TestCase):
     open_fn_name = "__builtin__.open" if USING_PYTHON2 else "builtins.open"
 
     def setUp(self):
-        self.client._swagger_spec = None
+        self.client.__class__._swagger_spec = None
         self.client._spec_valid_for_days = 1
         self.swagger_url = "test_swagger_url"
         self.client._session = requests.Session()
@@ -35,6 +35,9 @@ class TestDssSwaggerSpec(unittest.TestCase):
         self.dummy_response = requests.models.Response()
         self.dummy_response._content = b'{"swagger": ""}'
         self.dummy_response.status_code = 200
+
+    def tearDown(self):
+        self.client.__class__._swagger_spec = None
 
     def test_get_swagger_spec_new(self):
         with mock.patch('os.path.exists') as mock_exists, \
@@ -54,27 +57,27 @@ class TestDssSwaggerSpec(unittest.TestCase):
 
     def test_get_swagger_spec_cache_valid(self):
         with mock.patch('os.path.exists') as mock_exists, \
-                mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
-                mock.patch('os.makedirs') as mock_makedirs, \
-                mock.patch('requests.Session.get') as mock_get, \
-                mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
-                mock.patch(self.open_fn_name, mock_open()) as open_mock:
-                    mock_exists.return_value = True
-                    mock_days_since_last_modified.return_value = 0
-                    mock_get.return_value = self.dummy_response
+             mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
+             mock.patch('os.makedirs') as mock_makedirs, \
+             mock.patch('requests.Session.get') as mock_get, \
+             mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
+             mock.patch(self.open_fn_name, mock_open()) as open_mock:
+                mock_exists.return_value = True
+                mock_days_since_last_modified.return_value = 0
+                mock_get.return_value = self.dummy_response
 
-                    test = self.client.swagger_spec
-                    self.assertFalse(mock_makedirs.called)
-                    self.assertFalse(mock_get.called)
-                    self.assertFalse(open_mock().write.called)
+                test = self.client.swagger_spec
+                self.assertFalse(mock_makedirs.called)
+                self.assertFalse(mock_get.called)
+                self.assertFalse(open_mock().write.called)
 
     def test_get_swagger_spec_cache_expired(self):
         with mock.patch('os.path.exists') as mock_exists, \
-                mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
-                mock.patch('os.makedirs') as mock_makedirs, \
-                mock.patch('requests.Session.get') as mock_get, \
-                mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
-                mock.patch(self.open_fn_name, mock_open()) as open_mock:
+             mock.patch('hca.dss.SwaggerClient._get_days_since_last_modified') as mock_days_since_last_modified, \
+             mock.patch('os.makedirs') as mock_makedirs, \
+             mock.patch('requests.Session.get') as mock_get, \
+             mock.patch('hca.dss.SwaggerClient.load_swagger_json'), \
+             mock.patch(self.open_fn_name, mock_open()) as open_mock:
                     mock_exists.return_value = True
                     mock_days_since_last_modified.return_value = 2
                     mock_get.return_value = self.dummy_response


### PR DESCRIPTION
Currently, the DCP CLI fetches the DSS API definition once the first time it is run after installation and never updates after that. This change implements a strategy to refetch the DSS API definition after 7 days since the last update determined by the cached API definition's (`~/.config/hca/<base-64-encoded-swagger-url>.json`) last modified date. The refetch frequency is contestable if you guys have other ideas. 

One minor improvement we are considering is to enable content encoding on the DSS API to enable serving a compressed version of the API definition in order to minimize HCA CLI start up times. Granted, with an update policy of 1 week, this fetch would occur relatively infrequently and may go unnoticed. Further, the performance tradeoff between reducing payload size and adding a decompression step may not be significant. This change would require a small API Gateway configuration change, be applied to the entire DSS API and the compression of response payloads would be selective and invoked only by including an appropriate `Accept-Enconding` header on the API request. 

For more details:
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gzip-compression-decompression.html

Fixes #79 