### PR TITLE
Write/update DSS API definition atomically

### DIFF
--- a/hca/util/fs_helper.py
+++ b/hca/util/fs_helper.py
@@ -1,0 +1,79 @@
+import os, tempfile, errno, warnings
+from datetime import datetime
+
+
+class FSHelper(object):
+    """
+    Static helper class providing convenience methods for reading and writing files.
+    """
+
+    @staticmethod
+    def atomic_write(filename, shared_dir, content):
+        """
+        Atomically writes content a to file.
+
+        Writes to a temp file and renames file (atomic operation) to desired filename.
+        To ensure atomicity, the src and dest dirs must be the same.
+
+        :param filename: File name only (e.g. example.txt)
+        :param shared_dir: Shared directory of temp and dest file
+        :param content: Content to write to file
+        """
+        temp_filename = None
+        dest_filename = os.path.join(shared_dir, filename)
+        try:
+            with tempfile.NamedTemporaryFile('wb', dir=shared_dir, delete=False) as temp:
+                temp_filename = temp.name
+                temp.write(content)
+            FSHelper._atomic_rename(temp_filename, dest_filename)
+        finally:
+            if temp_filename and os.path.isfile(temp_filename):
+                try:
+                    os.remove(temp_filename)
+                except EnvironmentError:
+                    warnings.warn("\nFailed to clean up temporary file {}".format(temp_filename))
+
+    @staticmethod
+    def _atomic_rename(src, dest, max_retries=5):
+        """
+        Atomically renames a file.
+        Support for Unix and Windows platforms.
+
+        :param src: Source filename
+        :param dest: Destination filename
+        :param max_retries: Number of rename operation retries
+        """
+        for _ in range(max_retries):
+            try:
+                os.rename(src, dest)
+                return
+            except OSError as e:
+                FSHelper._handle_rename_error(e, src, dest)
+        warnings.warn("\nFailed to rename {} to {} after {} tries".format(src, dest, max_retries))
+
+    @staticmethod
+    def _handle_rename_error(err, src, dest):
+        """
+        Handles Windows specific rename error: https://docs.python.org/2/library/os.html#os.rename
+
+        :param err: OSError
+        :param src: Rename source filename
+        :param dest: Rename destination filename
+        """
+        if err.errno == errno.EEXIST:
+            try:
+                os.remove(dest)
+            except EnvironmentError:
+                warnings.warn("\nFailed to delete {}".format(dest))
+        else:
+            raise Exception("\nFailed to rename {} to {}".format(src, dest), err)
+
+    @staticmethod
+    def get_days_since_last_modified(filename):
+        """
+        :param filename: Absolute file path
+        :return: Number of days since filename's last modified time
+        """
+        now = datetime.now()
+        last_modified = datetime.fromtimestamp(os.path.getmtime(filename))
+        return (now - last_modified).days

--- a/test/test_fs_helper.py
+++ b/test/test_fs_helper.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import unittest
+import errno
+import warnings
+
+from hca.util.fs_helper import FSHelper
+from hca.util.compat import USING_PYTHON2
+
+if USING_PYTHON2:
+    import mock
+else:
+    from unittest import mock
+
+
+class TestFSHelper(unittest.TestCase):
+
+    def test_atomic_write(self):
+        filename = "some_file"
+        dir = "/some/dir"
+        content = "some content"
+        err = EnvironmentError()
+        with mock.patch('tempfile.NamedTemporaryFile') as mock_named_temporary_file, \
+                mock.patch('hca.util.fs._atomic_rename') as mock_atomic_rename, \
+                mock.patch('os.path.isfile') as mock_isfile, \
+                mock.patch('os.remove') as mock_remove, \
+                warnings.catch_warnings(record=True) as warn:
+            mock_temp_file = mock_named_temporary_file().__enter__()
+            mock_temp_file.name = "temp_name"
+            mock_isfile.return_value = True
+
+            FSHelper.atomic_write(filename, dir, content)
+            self.assertTrue(mock_temp_file.write.calledWith(content))
+            self.assertTrue(mock_atomic_rename.calledWith(mock_temp_file.name, filename))
+            self.assertTrue(mock_remove.calledWith(mock_temp_file.name))
+            self.assertTrue(len(warn) == 0)
+
+            mock_remove.side_effect = err
+            FSHelper.atomic_write(filename, dir, content)
+            self.assertTrue(len(warn) == 1)
+
+    def test_atomic_rename_ok(self):
+        src = "src"
+        dest = "dest"
+        with mock.patch('os.rename') as mock_rename, \
+                mock.patch('os.remove') as mock_remove:
+            FSHelper._atomic_rename(src, dest)
+            self.assertTrue(mock_rename.calledWith(src, dest))
+            self.assertFalse(mock_remove.called)
+
+    def test_atomic_rename_file_exists_error(self):
+        src = "src"
+        dest = "dest"
+        max_retries = 5
+        with mock.patch('os.rename') as mock_rename, \
+                mock.patch('hca.util.fs._handle_rename_error') as mock_handle_rename_error, \
+                warnings.catch_warnings(record=True) as warn:
+            err = OSError()
+            mock_rename.side_effect = err
+            FSHelper._atomic_rename(src, dest)
+            self.assertTrue(mock_rename.calledWith(src, dest))
+            self.assertEqual(mock_handle_rename_error.call_count, max_retries)
+            self.assertTrue(len(warn) == 1)
+
+    def test_handle_rename_windows_error(self):
+        src = "src"
+        dest = "dest"
+        err = OSError()
+        err.errno = errno.EEXIST
+        with mock.patch('os.remove') as mock_remove:
+            FSHelper._handle_rename_error(err, src, dest)
+            self.assertTrue(mock_remove.calledWith(dest))
+
+    def test_handle_rename_unknown_error(self):
+        src = "src"
+        dest = "dest"
+        err = OSError()
+        with mock.patch('os.remove') as mock_remove:
+            self.assertRaises(Exception, FSHelper._handle_rename_error, err, src, dest)
+            self.assertFalse(mock_remove.called)
+
+    def test_get_days_since_last_modified(self):
+        file = "file"
+        with mock.patch('os.path.getmtime') as mock_getmtime:
+            FSHelper.get_days_since_last_modified(file)
+            self.assertTrue(mock_getmtime.calledWith(file))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As per @ttung's suggestion (GH-139), these changes update the cached version of the DSS API definition atomically in order to avoid a race condition. This is achieved by writing the fetched file to a temp file and renamed (`os.rename`) to the desired filename, where [the latter operation is atomic](https://stackoverflow.com/questions/2333872/atomic-writing-to-file-with-python).

07/25/18 update:
These changes also handle `os.rename` [Windows specific behavior](https://docs.python.org/2/library/os.html#os.rename) by deleting the destination file if it exists before renaming. This process is attempted multiple times (5) in order to handle a potential race condition in which the destination file is recreated in between delete and rename operations. These changes also introduce `hca.util.fs_helper.py`, a static library of functions for interacting with the local filesystem.

Connected to #79 