### PR TITLE
Update docs to correct host configuration steps (#142) (#145)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,12 +47,14 @@ DSS deployment. You can also layer a minimal config file on top of the default `
     jq -n .DSSClient.swagger_url=env.SWAGGER_URL > ~/.config/hca/config.staging.json
     export HCA_CONFIG_FILE=~/.config/hca/config.staging.json
 
-To use the Python interface with a local or test DSS, set the ``host`` attribute of the API client:
+To use the Python interface with a local or test DSS, configure an HCAConfig object with a ``swagger_url`` field, and
+pass it as a parameter to the API client's constructor:
 
 .. code-block:: python
 
-    client = hca.dss.DSSClient()
-    client.host = "https://dss.example.com/v1"
+    config = HCAConfig()
+    config['DSSClient'].swagger_url = "https://dss.example.com/v1/swagger.json"
+    client = DSSClient(config=config)
     res = client.post_search(...)
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,14 @@ the hca package by running `make install` in the repository root directory.
 To use the command line interface with a local or test DSS, first run ``hca`` (or ``scripts/hca`` if you want to use the
 package in place from the repository root directory). This will create the file ``~/.config/hca/config.json``, which you
 can modify to update the value of `DSSClient.swagger_url` to point to the URL of the Swagger definition served by your
-DSS deployment. You can also layer a minimal config file on top of the default ``config.json`` using the
-``HCA_CONFIG_FILE`` environment variable, for example::
+DSS deployment. One caveat is that the CLI enforces HTTPS connection to the DSS API and is hardcoded in the source. In
+order to successfully connect to a local DSS, make this change in ``dcp-cli/hca/util/__init__.py`` in the
+`SwaggerClient` object::
+
+    scheme = "http"
+
+You can also layer a minimal config file on top of the default ``config.json`` using the ``HCA_CONFIG_FILE`` environment
+variable, for example::
 
     export SWAGGER_URL="https://dss.staging.data.humancellatlas.org/v1/swagger.json"
     jq -n .DSSClient.swagger_url=env.SWAGGER_URL > ~/.config/hca/config.staging.json

--- a/hca/config.py
+++ b/hca/config.py
@@ -4,6 +4,10 @@ from tweak import Config as _Config
 
 class HCAConfig(_Config):
     default_config_file = os.path.join(os.path.dirname(__file__), "default_config.json")
+
+    def __init__(self, *args, **kwargs):
+        super(HCAConfig, self).__init__(name="hca", *args, **kwargs)
+
     @property
     def config_files(self):
         return [self.default_config_file] + _Config.config_files.fget(self)
@@ -17,7 +21,7 @@ _config = None
 def get_config():
     global _config
     if _config is None:
-        _config = HCAConfig("hca")
+        _config = HCAConfig()
     return _config
 
 


### PR DESCRIPTION
The current steps for configuring a DSS API host for local development do not work for more complex use cases such as creating multiple `DSSClient` instances with different API hosts. These changes simply update the current docs to provide a correct method. This is due to a number of reasons which speak to the need to refactor/rethink how configuration is implemented in the CLI. A separate issue should (and will) be created to outline this work. Briefly, a couple issues are:

- `_swagger_spec` is a class variable on `SwaggerClient` forcing all instances to share the same host
- CLI configuration (includes `swagger_url` is written and loaded from cache implicitly, providing the user little visibility/control.

Connected to (#142) (#145)