### PR TITLE
help info for parameters appears in cli for upload and download

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,14 @@
+=================
+API documentation
+=================
+
+Data Storage System
+**********************
+.. automodule:: hca.dss
+   :members:
+   :inherited-members:
+
+Upload Service
+**********************
+.. automodule:: hca.upload
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,14 +1,9 @@
 =================
 API documentation
 =================
-
-Data Storage System
-**********************
 .. automodule:: hca.dss
    :members:
    :inherited-members:
 
-Upload Service
-**********************
 .. automodule:: hca.upload
    :members:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,7 @@
+=================
+CLI documentation
+=================
+.. argparse::
+   :module: hca.cli
+   :func: get_parser
+   :prog: hca

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath('..'))  # noqa
 
-from hca.dss import DSSClient
-dss_client = DSSClient()
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -49,14 +46,15 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'hca-cli'
+project = 'HCA CLI'
 copyright = '2017, James Mackey, Andrey Kislyuk'
 author = 'James Mackey'
 
 # A string of reStructuredText that will be included at the end of every source file that is read.
-rst_epilog = """* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`"""
+rst_epilog = """
+.. rubric:: Links:
+    :ref:`genindex` / :ref:`modindex` / :ref:`search`
+"""
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ dss_client = DSSClient()
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinxarg.ext']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -52,6 +52,11 @@ master_doc = 'index'
 project = 'hca-cli'
 copyright = '2017, James Mackey, Andrey Kislyuk'
 author = 'James Mackey'
+
+# A string of reStructuredText that will be included at the end of every source file that is read.
+rst_epilog = """* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`"""
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,6 @@
-.. include:: ../README.rst
-
-API documentation
-=================
-
-.. automodule:: hca.dss
-   :members:
-   :inherited-members:
+=======
+HCA CLI
+=======
 
 Table of Contents
 =================
@@ -13,4 +8,6 @@ Table of Contents
 .. toctree::
    :maxdepth: 5
 
+   readme
    cli
+   api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,12 @@
-=======
-HCA CLI
-=======
+.. include:: ../README.rst
+
 
 Table of Contents
-=================
-
+-----------------
 .. toctree::
    :maxdepth: 5
 
-   readme
+   index
    cli
    api
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,4 @@ Table of Contents
 .. toctree::
    :maxdepth: 5
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   cli

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,0 @@
-.. include:: ../README.rst

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst

--- a/hca/cli.py
+++ b/hca/cli.py
@@ -40,8 +40,7 @@ class HCAArgumentParser(argparse.ArgumentParser):
             self._defaults.pop("entry_point", None)
         return subparser
 
-
-def main(args=None):
+def get_parser():
     parser = HCAArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     version_string = "%(prog)s {version} ({python_impl} {python_version} {platform})"
     parser.add_argument("--version", action="version", version=version_string.format(
@@ -62,7 +61,10 @@ def main(args=None):
     dss_cli.add_commands(parser._subparsers)
 
     argcomplete.autocomplete(parser)
+    return parser
 
+def main(args=None):
+    parser = get_parser()
     if len(sys.argv) < 2:
         parser.print_help()
         parser.exit(1)

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -38,19 +38,23 @@ class DSSClient(SwaggerClient):
         """
         Download a bundle and save it to the local filesystem as a directory.
 
-        `metadata_files` (`--metadata-files` on the CLI) are one or more shell patterns against which all metadata
-        files in the bundle will be matched case-sensitively. A file is considered a metadata file if the `indexed`
-        property in the manifest is set. If and only if a metadata file matches any of the patterns in
-        `metadata_files` will it be downloaded.
+        :param str bundle_uuid: The uuid of the bundle to download
+        :param str replica: the replica to download from. [aws,gcp,azure]
+        :param str version: Timestamp of bundle creation in RFC3339. The version to download, else download the latest.
+        :param str dest_name: The destination file path for the download
+        :param list metadata_files: one or more shell patterns against which all metadata files in the bundle will be
+            matched case-sensitively. A file is considered a metadata file if the `indexed` property in the manifest is
+            set. If and only if a metadata file matches any of the patterns in `metadata_files` will it be downloaded.
+        :param list data_files: one or more shell patterns against which all data files in the bundle will be matched
+            case-sensitively. A file is considered a data file if the `indexed` property in the manifest is not set. If
+            and only if a data file matches any of the patterns in `data_files` will it be downloaded.
+        :param int initial_retries_left: The initial number of times to retries a failed download.
+        :param float min_delay_seconds: The minimum number of seconds to wait in between retries.
 
-        `data_files` (`--data-files` on the CLI) are one or more shell patterns against which all data files in the
-        bundle will be matched case-sensitively. A file is considered a data file if the `indexed` property in the
-        manifest is not set. If and only if a data file matches any of the patterns in `data_files` will it be
-        downloaded.
-
+        Download a bundle and save it to the local filesystem as a directory.
         By default, all data and metadata files are downloaded. To disable the downloading of data files,
-        use `--data-files ''` if using the CLI (or `data_files=()` if invoking `download` programmatically). Likewise
-        for metadata files.
+        use `--data-files ''` if using the CLI (or `data_files=()` if invoking `download` programmatically).
+        Likewise for metadata files.
         """
         if not dest_name:
             dest_name = bundle_uuid
@@ -168,17 +172,26 @@ class DSSClient(SwaggerClient):
         """
         Process the given manifest file in TSV (tab-separated values) format and download the files referenced by it.
 
-        Each row in the manifest represents one file in DSS. The manifest must have a header row. The header row must
-        declare the following columns:
+        :param str manifest: path to a TSV (tab-separated values) file listing files to download
+        :param str replica: the replica to download from. [aws,gcp,azure]
+        :param int initial_retries_left: The initial number of times to retries a failed download.
+        :param float min_delay_seconds: The minimum number of seconds to wait in between retries.
 
-        `bundle_uuid` - the UUID of the bundle containing the file in DSS
+        Process the given manifest file in TSV (tab-separated values) format and download the files
+        referenced by it.
 
-        `bundle_version` - the version of the bundle containing the file in DSS
+        Each row in the manifest represents one file in DSS. The manifest must have a header row. The header row
+        must declare the following columns:
 
-        `file_name` - the name of the file as specified in the bundle
+        * `bundle_uuid` - the UUID of the bundle containing the file in DSS.
+
+        * `bundle_version` - the version of the bundle containing the file in DSS.
+
+        * `file_name` - the name of the file as specified in the bundle.
 
         The TSV may have additional columns. Those columns will be ignored. The ordering of the columns is
         insignificant because the TSV is required to have a header row.
+
         """
         with open(manifest) as f:
             bundles = defaultdict(set)
@@ -211,6 +224,12 @@ class DSSClient(SwaggerClient):
         """
         Upload a directory of files from the local filesystem and create a bundle containing the uploaded files.
 
+        :param str src_dir: file path to a directory of file to upload
+        :param str replica: the replica to upload to. [aws,gcp,azure]
+        :param str staging_bucket: the bucket to upload from.
+        :param int timeout_seconds: timeout.
+
+        Upload a directory of files from the local filesystem and create a bundle containing the uploaded files.
         This method requires the use of a client-controlled object storage bucket to stage the data for upload.
         """
         bundle_uuid = str(uuid.uuid4())

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -1,3 +1,8 @@
+"""
+Data Storage System
+*******************
+"""
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import defaultdict

--- a/hca/upload/__init__.py
+++ b/hca/upload/__init__.py
@@ -1,3 +1,8 @@
+"""
+Upload Service
+**************
+"""
+
 from .credentials_manager import CredentialsManager
 from .upload_config import UploadConfig
 from .upload_area import UploadArea, UploadAreaURI

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -505,18 +505,18 @@ class SwaggerClient(object):
         arguments. Any other text is combined and added to the argparse description.
 
         example:
-        \"\"\"
-            this will be the summary
+            \"""
+             this will be the summary
 
-            :param name: describe the parameter called name.
+             :param name: describe the parameter called name.
 
-            this will be the descriptions
+             this will be the descriptions
 
-            * more description
-            * more description
+             * more description
+             * more description
 
-            This will also be in the description
-        \"\"\"
+             This will also be in the description
+            \"""
 
         :param str docstring:
         :return:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -91,8 +91,13 @@ except ImportError:
     from funcsigs import signature, Signature, Parameter
 
 import requests
+
+from docutils import utils
+from docutils.frontend import OptionParser
+from docutils.parsers.rst import Parser as RSTParser_component
 from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
+from sphinx.parsers import RSTParser
 from urllib3.util import retry, timeout
 from jsonpointer import resolve_pointer
 
@@ -480,11 +485,64 @@ class SwaggerClient(object):
             sig = signature(command)
             if not getattr(command, "__doc__", None):
                 raise SwaggerClientInternalError("Command {} has no docstring".format(command))
-            doc = command.__doc__.strip().format(prog=subparsers._prog_prefix)
-            command_subparser = subparsers.add_parser(command.__name__,
-                                                      help=doc.splitlines()[0],
-                                                      description=doc)
+            docstring = command.__doc__.format(prog=subparsers._prog_prefix)
+            method_args = self.parse_docstring(docstring)
+            command_subparser = subparsers.add_parser(command.__name__.replace("_", "-"),
+                                                      help=method_args['summary'],
+                                                      description=method_args['description']
+                                                      )
             command_subparser.set_defaults(entry_point=self._command_arg_forwarder_factory(command, sig))
             for param_name, param_data in sig.parameters.items():
                 command_subparser.add_argument("--" + param_name.replace("_", "-"),
+                                               help=method_args['params'].get(param_name, None),
                                                **self._get_command_arg_settings(param_data))
+
+    @staticmethod
+    def parse_docstring(docstring):
+        """
+        Using the sphinx RSTParse to parse __doc__ for argparse `parameters`, `help`, and `description`. The first
+        rst paragraph encountered it treated as the argparse help text. Any param fields are treated as argparse
+        arguments. Any other text is combined and added to the argparse description.
+
+        example:
+        \"\"\"
+            this will be the summary
+
+            :param name: describe the parameter called name.
+
+            this will be the descriptions
+
+            * more description
+            * more description
+
+            This will also be in the description
+        \"\"\"
+
+        :param str docstring:
+        :return:
+        :rtype: dict
+        """
+        settings = OptionParser(components=(RSTParser_component,)).get_default_values()
+        rstparser = RSTParser()
+        document = utils.new_document(' ', settings)
+        rstparser.parse(docstring, document)
+        if document.children[0].tagname != 'block_quote':
+            logger.warning("The first line of the docstring must be blank.")
+        else:
+            document = document.children[0]
+
+        def get_params(field_list_node, params):
+            for field in field_list_node.children:
+                name = field.children[0].rawsource.split(' ')
+                if 'param' == name[0]:
+                    params[name[-1]] = field.children[1].astext()
+
+        method_args = {'summary': '', 'params': dict(), 'description': ''}
+        for node in document.children:
+            if node.tagname is 'paragraph' and method_args['summary'] == '':
+                method_args['summary'] = node.astext()
+            elif node.tagname is 'field_list':
+                get_params(node, method_args['params'])
+            else:
+                method_args['description'] += '\n' + node.astext()
+        return method_args

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -482,7 +482,7 @@ class SwaggerClient(object):
             if not getattr(command, "__doc__", None):
                 raise SwaggerClientInternalError("Command {} has no docstring".format(command))
             docstring = command.__doc__.format(prog=subparsers._prog_prefix)
-            method_args = parse_docstring(docstring)
+            method_args = _parse_docstring(docstring)
             command_subparser = subparsers.add_parser(command.__name__.replace("_", "-"),
                                                       help=method_args['summary'],
                                                       description=method_args['description']

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -92,19 +92,15 @@ except ImportError:
 
 import requests
 
-from docutils import utils
-from docutils.frontend import OptionParser
-from docutils.parsers.rst import Parser as RSTParser_component
 from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
-from sphinx.parsers import RSTParser
 from urllib3.util import retry, timeout
 from jsonpointer import resolve_pointer
 
 from .. import get_config, logger
 from .compat import USING_PYTHON2
 from .exceptions import SwaggerAPIException, SwaggerClientInternalError
-from ._docs import _pagination_docstring, _streaming_docstring, _md2rst
+from ._docs import _pagination_docstring, _streaming_docstring, _md2rst, _parse_docstring
 from .fs_helper import FSHelper as fs
 
 
@@ -486,7 +482,7 @@ class SwaggerClient(object):
             if not getattr(command, "__doc__", None):
                 raise SwaggerClientInternalError("Command {} has no docstring".format(command))
             docstring = command.__doc__.format(prog=subparsers._prog_prefix)
-            method_args = self.parse_docstring(docstring)
+            method_args = parse_docstring(docstring)
             command_subparser = subparsers.add_parser(command.__name__.replace("_", "-"),
                                                       help=method_args['summary'],
                                                       description=method_args['description']
@@ -496,53 +492,3 @@ class SwaggerClient(object):
                 command_subparser.add_argument("--" + param_name.replace("_", "-"),
                                                help=method_args['params'].get(param_name, None),
                                                **self._get_command_arg_settings(param_data))
-
-    @staticmethod
-    def parse_docstring(docstring):
-        """
-        Using the sphinx RSTParse to parse __doc__ for argparse `parameters`, `help`, and `description`. The first
-        rst paragraph encountered it treated as the argparse help text. Any param fields are treated as argparse
-        arguments. Any other text is combined and added to the argparse description.
-
-        example:
-            \"""
-             this will be the summary
-
-             :param name: describe the parameter called name.
-
-             this will be the descriptions
-
-             * more description
-             * more description
-
-             This will also be in the description
-            \"""
-
-        :param str docstring:
-        :return:
-        :rtype: dict
-        """
-        settings = OptionParser(components=(RSTParser_component,)).get_default_values()
-        rstparser = RSTParser()
-        document = utils.new_document(' ', settings)
-        rstparser.parse(docstring, document)
-        if document.children[0].tagname != 'block_quote':
-            logger.warning("The first line of the docstring must be blank.")
-        else:
-            document = document.children[0]
-
-        def get_params(field_list_node, params):
-            for field in field_list_node.children:
-                name = field.children[0].rawsource.split(' ')
-                if 'param' == name[0]:
-                    params[name[-1]] = field.children[1].astext()
-
-        method_args = {'summary': '', 'params': dict(), 'description': ''}
-        for node in document.children:
-            if node.tagname is 'paragraph' and method_args['summary'] == '':
-                method_args['summary'] = node.astext()
-            elif node.tagname is 'field_list':
-                get_params(node, method_args['params'])
-            else:
-                method_args['description'] += '\n' + node.astext()
-        return method_args

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -1,5 +1,12 @@
 import CommonMark
 
+from docutils import utils
+from docutils.frontend import OptionParser
+from docutils.parsers.rst import Parser as RSTParser_component
+from sphinx.parsers import RSTParser
+
+from .. import logger
+
 _pagination_docstring = """
 .. admonition:: Pagination
 
@@ -40,3 +47,53 @@ def _md2rst(docstring):
     ast = parser.parse(docstring)
     renderer = CommonMark.ReStructuredTextRenderer()
     return renderer.render(ast)
+
+
+def _parse_docstring(docstring):
+    """
+    Using the sphinx RSTParse to parse __doc__ for argparse `parameters`, `help`, and `description`. The first
+    rst paragraph encountered it treated as the argparse help text. Any param fields are treated as argparse
+    arguments. Any other text is combined and added to the argparse description.
+
+    example:
+        \"""
+         this will be the summary
+
+         :param name: describe the parameter called name.
+
+         this will be the descriptions
+
+         * more description
+         * more description
+
+         This will also be in the description
+        \"""
+
+    :param str docstring:
+    :return:
+    :rtype: dict
+    """
+    settings = OptionParser(components=(RSTParser_component,)).get_default_values()
+    rstparser = RSTParser()
+    document = utils.new_document(' ', settings)
+    rstparser.parse(docstring, document)
+    if document.children[0].tagname != 'block_quote':
+        logger.warning("The first line of the docstring must be blank.")
+    else:
+        document = document.children[0]
+
+    def get_params(field_list_node, params):
+        for field in field_list_node.children:
+            name = field.children[0].rawsource.split(' ')
+            if 'param' == name[0]:
+                params[name[-1]] = field.children[1].astext()
+
+    method_args = {'summary': '', 'params': dict(), 'description': ''}
+    for node in document.children:
+        if node.tagname is 'paragraph' and method_args['summary'] == '':
+            method_args['summary'] = node.astext()
+        elif node.tagname is 'field_list':
+            get_params(node, method_args['params'])
+        else:
+            method_args['description'] += '\n' + node.astext()
+    return method_args

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -2,8 +2,7 @@ import CommonMark
 
 from docutils import utils
 from docutils.frontend import OptionParser
-from docutils.parsers.rst import Parser as RSTParser_component
-from sphinx.parsers import RSTParser
+from docutils.parsers.rst import Parser as RSTParser
 
 from .. import logger
 
@@ -73,7 +72,7 @@ def _parse_docstring(docstring):
     :return:
     :rtype: dict
     """
-    settings = OptionParser(components=(RSTParser_component,)).get_default_values()
+    settings = OptionParser(components=(RSTParser,)).get_default_values()
     rstparser = RSTParser()
     document = utils.new_document(' ', settings)
     rstparser.parse(docstring, document)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,5 @@ responses
 backports.tempfile
 mock
 unittest2
+sphinx-argparse
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ responses
 backports.tempfile
 mock
 unittest2
+Sphinx
 sphinx-argparse
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tweak >= 0.6.7, < 1
 dcplib >= 1.3.2, < 2
 argcomplete >= 1.9.3, < 2
 commonmark >= 0.7.4, < 1
+docutils >= 0.14, < 1


### PR DESCRIPTION
# Release Notes
- Using sphinx-argparser to generate documentation for the CLI into cli.rst
- refactored docstrings to restructed text format
- TOC now populates in sphinx documentation
- added common links to epilog in sphinx documentation
- using sphinx RSTParser to parse docstrings into argparser
- spread out documentation across api.rst, readme.rst, cli.rst, and index.rst

# Known Issue
- the sphinx documentation **incorrectly** marks all commands generated from a swagger doc as a `classmethod`.