### PR TITLE
Restrict Boto3 dependency version range to 1.7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3 >= 1.4, < 2
+boto3 >= 1.4, < 1.8
 crcmod >= 1.7, < 2
 google-auth >= 1.0.2, < 2
 google-auth-oauthlib >= 0.1, < 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3 >= 1.4, < 1.8
+boto3 >= 1.7, < 1.8
 crcmod >= 1.7, < 2
 google-auth >= 1.0.2, < 2
 google-auth-oauthlib >= 0.1, < 2


### PR DESCRIPTION
Pending fix for https://github.com/spulec/moto/issues/1793