### PR TITLE
Enable programmatic SwaggerClient host configuration (#142)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,16 @@ the hca package by running `make install` in the repository root directory.
 
 To use the command line interface with a local or test DSS, first run ``hca`` (or ``scripts/hca`` if you want to use the
 package in place from the repository root directory). This will create the file ``~/.config/hca/config.json``, which you
-can modify to update the value of `DSSClient.swagger_url` to point to the URL of the Swagger definition served by your
-DSS deployment. Lastly, the CLI enforces HTTPS connection to the DSS API. If you are connecting to a local DSS, make this
-change in ``dcp-cli/hca/util/__init__.py`` in the `SwaggerClient` object::
+can modify to update the value of ``DSSClient.swagger_url`` to point to the URL of the Swagger definition served by your
+DSS deployment. Lastly, the CLI enforces HTTPS connection to the DSS API. If you are connecting to a local DSS, make
+this change in ``dcp-cli/hca/util/__init__.py`` in the ``SwaggerClient`` object::
 
     scheme = "http"
+
+To use the Python interface with a local or test DSS, pass the URL of the Swagger definition to the ``DSSClient``
+constructor via the ``swagger_url`` parameter::
+
+    client = DSSClient(swagger_url="https://dss.example.com/v1/swagger.json")
 
 You can also layer a minimal config file on top of the default ``config.json`` using the ``HCA_CONFIG_FILE`` environment
 variable, for example::
@@ -51,16 +56,6 @@ variable, for example::
     export SWAGGER_URL="https://dss.staging.data.humancellatlas.org/v1/swagger.json"
     jq -n .DSSClient.swagger_url=env.SWAGGER_URL > ~/.config/hca/config.staging.json
     export HCA_CONFIG_FILE=~/.config/hca/config.staging.json
-
-To use the Python interface with a local or test DSS, configure an HCAConfig object with a ``swagger_url`` field, and
-pass it as a parameter to the API client's constructor:
-
-.. code-block:: python
-
-    config = HCAConfig()
-    config['DSSClient'].swagger_url = "https://dss.example.com/v1/swagger.json"
-    client = DSSClient(config=config)
-    res = client.post_search(...)
 
 Testing
 -------

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -45,8 +45,8 @@ class TestDssApi(unittest.TestCase):
         num_threads = 2
         for repeat in range(num_repeats):
             with self.subTest(repeat=repeat):
-                with TemporaryDirectory() as home:
-                    with mock.patch.dict(os.environ, HOME=home):
+                with TemporaryDirectory() as config_dir:
+                    with mock.patch.dict(os.environ, XDG_CONFIG_HOME=config_dir):
 
                         def f(_):
                             dev = hca.dss.DSSClient(

--- a/test/integration/util/test_swagger_client.py
+++ b/test/integration/util/test_swagger_client.py
@@ -90,7 +90,7 @@ class TestSwaggerClient(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.client.__class__._swagger_spec = None
+        cls.client._swagger_spec = None
 
     def setUp(self):
         self.client._session = requests.Session()

--- a/test/unit/util/test_get_swagger_spec.py
+++ b/test/unit/util/test_get_swagger_spec.py
@@ -50,12 +50,12 @@ class TestSwaggerClient(unittest.TestCase):
             cls.client = hca.util.SwaggerClient(config)
 
     def setUp(self):
-        self.client.__class__._swagger_spec = None
+        self.client._swagger_spec = None
         self.client._spec_valid_for_days = 1
         self.client._session = requests.Session()
 
     def tearDown(self):
-        self.client.__class__._swagger_spec = None
+        self.client._swagger_spec = None
 
     def test_get_swagger_spec_new(self):
         with mock.patch('os.path.exists') as mock_exists, \


### PR DESCRIPTION
Resolves host configuration issues when creating multiple SwaggerClient instances across multiple threads by:
- refactoring `_swagger_spec` field from a class var to an instance var
- enabling host configuration during client initialization

Specifically, host configuration is done via the `swagger_url` parameter in the client constructor. This is because the Swagger definition, which is served by `swagger_url`, provides information about the API and is the source of truth for the API host.

Fixes #142 