### PR TITLE
Support for OIDC JWT for Authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3 >= 1.7, < 1.8
 crcmod >= 1.7, < 2
+cryptography==2.3.1
 google-auth >= 1.0.2, < 2
 google-auth-oauthlib >= 0.1, < 2
 Jinja2 >= 2.9, < 3
@@ -12,3 +13,4 @@ dcplib >= 1.3.2, < 2
 argcomplete >= 1.9.3, < 2
 commonmark >= 0.7.4, < 0.8
 docutils >= 0.14, < 1
+PyJWT >= 1.6.4

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -262,7 +262,7 @@ class TestDssApi(unittest.TestCase):
                 break
 
     @reset_tweak_changes
-    def test_python_login_logout(self):
+    def test_python_login_logout_service_acount(self):
         client = hca.dss.DSSClient()
         query = {'bool': {}}
         resp = client.put_subscription(es_query=query, callback_url="https://www.example.com", replica="aws")
@@ -274,9 +274,27 @@ class TestDssApi(unittest.TestCase):
         config = hca.get_config()
 
         self.assertEqual(config.oauth2_token.access_token, access_token)
+        client.logout()
+        self.assertNotIn("oauth2_token", config)
+
+    @unittest.skipIf(True, "Manual Test")
+    @reset_tweak_changes
+    def test_python_login_logout_user_account(self):
+        client = hca.dss.DSSClient()
+        config = hca.get_config()
 
         client.logout()
+        self.assertNotIn("oauth2_token", config)
 
+        client.login()
+        self.assertIn("oauth2_token", config)
+
+        query = {'bool': {}}
+        resp = client.put_subscription(es_query=query, callback_url="https://www.example.com", replica="aws")
+        self.assertIn("uuid", resp)
+        client.delete_subscription(uuid=resp["uuid"], replica="aws")
+
+        client.logout()
         self.assertNotIn("oauth2_token", config)
 
 


### PR DESCRIPTION
JWT are now generated and used for authentication with the dss as outlined in https://allspark.dev.data.humancellatlas.org/dcp-ops/docs/wikis/Security/Authentication%20and%20Authorization/Setting%20up%20DCP%20Auth

This and https://github.com/HumanCellAtlas/data-store/pull/1542 are **dependent** on each other for integration tests to **pass**. This needs to be merge this **after** https://github.com/HumanCellAtlas/data-store/pull/1542. 

