### PR TITLE
fix 0-byte file download (#132)

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -113,6 +113,9 @@ class DSSClient(SwaggerClient):
             retries_left = num_retries
             hasher = hashlib.sha256()
             with open(file_path, "wb") as fh:
+                if file_['size'] == 0:
+                    logger.info("%s", "File {}: CREATED (empty). Stored at {}.".format(filename, file_path))
+                    continue
                 while True:
                     try:
                         response = self.get_file._request(


### PR DESCRIPTION
Range HTTP requests fail and return response code 416 if the requested range is not satisfiable - e.g. requesting a range starting from 0-bytes on a 0-byte file.

Fixes #132