### PR TITLE
Fixing read the docs error with markup language in argsparser

### DIFF
--- a/docs/_static/text_wrapping.css
+++ b/docs/_static/text_wrapping.css
@@ -1,0 +1,6 @@
+.wy-table-responsive table td {
+    white-space: normal !important;
+}
+.wy-table-responsive {
+    overflow: visible !important;
+}

--- a/docs/_static/text_wrapping.css
+++ b/docs/_static/text_wrapping.css
@@ -1,3 +1,4 @@
+/* From https://sphinx-argparse.readthedocs.io/en/stable/misc.html#text-wrapping-in-argument-tables */
 .wy-table-responsive table td {
     white-space: normal !important;
 }

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -5,3 +5,4 @@ CLI documentation
    :module: hca.cli
    :func: get_parser
    :prog: hca
+   :markdownhelp:


### PR DESCRIPTION
*  The swagger doc that is used to generate the cli argparser was failing to render using sphinx-argparse because of markdown in the parameter descriptions. This was fixed by telling sphinx-argparser to expect markups.
* adding css for text wrapping long parameter descriptions in read the docs.