### PR TITLE
Improve thread safety of SwaggerClient

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -469,7 +469,7 @@ class SwaggerClient(object):
         docstring += "\n\n" + _md2rst(method_data["description"])
         client_method.__doc__ = docstring
 
-        setattr(self.__class__, method_name, types.MethodType(client_method, SwaggerClient))
+        setattr(self, method_name, types.MethodType(client_method, SwaggerClient))
         self.methods[method_name] = dict(method_data, entry_point=getattr(self, method_name)._cli_call,
                                          signature=client_method.__signature__, args=method_args)
 


### PR DESCRIPTION
SwaggerClient discovers methods by reading a swagger document, creating
instances of _ClientMethodFactory for paths in the swagger, and
assigning those instances as class attributes of SwaggerClient.

This means that a single instance of each _ClientMethodFactory is shared
across threads. This is not so good because _ClientMethodFactories
store state associated with requests. In particular, consider the
following scenario:

```
Thread-1: client = hca.dss.DSSClient()
Thread-2: client = hca.dss.DSSClient()
Thread-1: with client.get_file.stream(...) as handle:
Thread-2: with client.get_file.stream(...) as handle:
Thread-1: handle.raw.read()
```

Depending on the execution of `__enter__`, Thread-1 may have just read from
the file for Thread-2! Going on,

```
Thread-1: __exit__ the with block
Thread-2: handle.raw.read()
Thread-2: __exit__ the with block
Exception: NoneType has no attribute close()
```

Or you know, something like that.

This change makes the methods instance attributes.