### PR TITLE
removing redirect for retry_policy

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -183,7 +183,6 @@ class SwaggerClient(object):
     scheme = "https"
     retry_policy = RetryPolicy(read=10,
                                status=10,
-                               redirect=3,
                                backoff_factor=0.1,
                                status_forcelist=frozenset({500, 502, 503, 504}))
     token_expiration = 3600


### PR DESCRIPTION
This will fix an issue mention [here](https://github.com/HumanCellAtlas/dcp-cli/pull/184#issuecomment-438716776), when downloading large files.