### PR TITLE
Adding refresh-swagger command

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -216,7 +216,7 @@ class SwaggerClient(object):
         else:
             self.__class__.__doc__ = _md2rst(self.swagger_spec["info"]["description"])
         self.methods = {}
-        self.commands = [self.login, self.logout]
+        self.commands = [self.login, self.logout, self.refresh_swagger]
         self.http_paths = collections.defaultdict(dict)
         self.host = "{scheme}://{host}{base}".format(scheme=self.scheme,
                                                      host=self.swagger_spec["host"],
@@ -253,8 +253,7 @@ class SwaggerClient(object):
                     if not swagger_filename.startswith("/"):
                         swagger_filename = os.path.join(os.path.dirname(__file__), swagger_filename)
                 else:
-                    swagger_filename = base64.urlsafe_b64encode(self.swagger_url.encode()).decode() + ".json"
-                    swagger_filename = os.path.join(self.config.user_config_dir, swagger_filename)
+                    swagger_filename = self._get_swagger_filename(self.swagger_url)
                 if (("swagger_filename" not in self.config) and
                     ((not os.path.exists(swagger_filename)) or
                      (fs.get_days_since_last_modified(swagger_filename) >= self._spec_valid_for_days))):
@@ -270,6 +269,21 @@ class SwaggerClient(object):
                 with open(swagger_filename) as fh:
                     self._swagger_spec = self.load_swagger_json(fh)
         return self._swagger_spec
+
+    def _get_swagger_filename(self, swagger_url):
+        swagger_filename = base64.urlsafe_b64encode(swagger_url.encode()).decode() + ".json"
+        swagger_filename = os.path.join(self.config.user_config_dir, swagger_filename)
+        return swagger_filename
+
+    def refresh_swagger(self):
+        """
+        Manually refresh the swagger document. This can help resolve errors communicate with the API.
+        """
+        try:
+            os.remove(self._get_swagger_filename(self.swagger_url))
+        except FileNotFoundError:
+            pass
+        self.__init__()
 
     @property
     def application_secrets(self):

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -281,9 +281,10 @@ class SwaggerClient(object):
         """
         try:
             os.remove(self._get_swagger_filename(self.swagger_url))
-        except FileNotFoundError:
-            pass
-        self.__init__()
+        except EnvironmentError as e:
+            logger.warn(os.strerror(e.errno))
+        else:
+            self.__init__()
 
     @property
     def application_secrets(self):

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -261,6 +261,19 @@ class TestDssApi(unittest.TestCase):
             if ix > limit:
                 break
 
+    def test_refresh_swagger(self):
+        """Testing refresh_swagger by comparing the creation date of the old swagger with the refreshed swagger that
+        replaces it"""
+        client = hca.dss.DSSClient()
+
+        swagger_filename = client._get_swagger_filename(client.swagger_url)
+        self.assertTrue(os.path.isfile(swagger_filename), "Pass if file exists initially")
+        old_swagger = datetime.datetime.fromtimestamp(os.path.getmtime(swagger_filename))
+        client.refresh_swagger()
+        new_swagger = datetime.datetime.fromtimestamp(os.path.getmtime(swagger_filename))
+        self.assertGreater(new_swagger, old_swagger)
+
+
     @reset_tweak_changes
     def test_python_login_logout_service_acount(self):
         client = hca.dss.DSSClient()


### PR DESCRIPTION
- This command will work for both the CLI and Python binding
- This command fetches the current swagger doc and refreshes the client.