### PR TITLE
post to upload api after successful file upload via hca cli

### DIFF
--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -53,6 +53,7 @@ class UploadArea:
             raise UploadException("You must provide a uuid or URI")
         self.uuid = self.uri.area_uuid
         self.s3_agent = None
+        self.upload_api_client = ApiClient(self.uri.deployment_stage)
 
     def __str__(self):
         return "UploadArea {uri}".format(uri=self.uri)
@@ -86,7 +87,6 @@ class UploadArea:
         :param detail: return detailed file information (slower)
         :return: a list of dicts containing at least 'name', or more of detail was requested
         """
-        upload_api_client = ApiClient(self.uri.deployment_stage)
         creds_provider = CredentialsManager(upload_area=self)
         s3agent = S3Agent(credentials_provider=creds_provider)
         key_prefix = self.uuid + "/"
@@ -94,7 +94,7 @@ class UploadArea:
         for page in s3agent.list_bucket_by_page(bucket_name=self.uri.bucket_name, key_prefix=key_prefix):
             file_list = [key[key_prefix_length:] for key in page]  # cut off upload-area-id/
             if detail:
-                files_info = upload_api_client.files_info(self.uuid, file_list)
+                files_info = self.upload_api_client.files_info(self.uuid, file_list)
             else:
                 files_info = [{'name': filename} for filename in file_list]
             for file_info in files_info:
@@ -140,6 +140,7 @@ class UploadArea:
             content_type = str(DcpMediaType.from_file(file_path, dcp_type))
             self.s3agent.upload_file(file_path, self.uri.bucket_name, file_s3_key, content_type, report_progress=report_progress)
             self.s3agent.file_upload_completed_count += 1
+            self.upload_api_client.notify_on_file_upload(file_s3_key)
             print("Upload complete of %s to upload area %s" % (file_path, file_s3_key))
         except Exception as e:
             self.s3agent.failed_uploads[file_path] = e

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -140,7 +140,7 @@ class UploadArea:
             content_type = str(DcpMediaType.from_file(file_path, dcp_type))
             self.s3agent.upload_file(file_path, self.uri.bucket_name, file_s3_key, content_type, report_progress=report_progress)
             self.s3agent.file_upload_completed_count += 1
-            self.upload_api_client.notify_on_file_upload(file_s3_key)
+            self.upload_api_client.file_upload_notification(self.uuid, target_filename or os.path.basename(file_path))
             print("Upload complete of %s to upload area %s" % (file_path, file_s3_key))
         except Exception as e:
             self.s3agent.failed_uploads[file_path] = e

--- a/hca/upload/upload_submission_state.py
+++ b/hca/upload/upload_submission_state.py
@@ -59,8 +59,6 @@ class FileStatusCheck(object):
         try:
             response = self.upload_api_client.validation_status(upload_area, file_id)
         except RuntimeError as e:
-            import pdb
-            pdb.set_trace()
             return 'VALIDATION_STATUS_RETRIEVAL_ERROR: {}'.format(e)
         validation_status = response['validation_status']
         if validation_status == 'SCHEDULED':

--- a/test/integration/upload/__init__.py
+++ b/test/integration/upload/__init__.py
@@ -75,7 +75,6 @@ class UploadTestCase(unittest.TestCase):
         if re.search('\{stage\}', api_host):
             api_host = api_host.format(stage=stage)
         url = 'https://{api_host}/v1/area/{uuid}/{name}'.format(api_host=api_host, uuid=area_uuid, name=filename)
-        import pdb; pdb.set_trace()
         responses.add(responses.POST, url, status=202)
         return url
 

--- a/test/integration/upload/__init__.py
+++ b/test/integration/upload/__init__.py
@@ -69,6 +69,16 @@ class UploadTestCase(unittest.TestCase):
         responses.add(responses.POST, creds_url, json=creds, status=201)
         return creds_url
 
+    def simulate_file_upload_notification_api(self, area_uuid, filename,
+                                              api_host="upload.{stage}.data.humancellatlas.org",
+                                              stage='test'):
+        if re.search('\{stage\}', api_host):
+            api_host = api_host.format(stage=stage)
+        url = 'https://{api_host}/v1/area/{uuid}/{name}'.format(api_host=api_host, uuid=area_uuid, name=filename)
+        import pdb; pdb.set_trace()
+        responses.add(responses.POST, url, status=202)
+        return url
+
     def _setup_tweak_config(self):
         config = hca.get_config()
         config.upload = {

--- a/test/integration/upload/test_api_client.py
+++ b/test/integration/upload/test_api_client.py
@@ -4,6 +4,8 @@
 import os
 import sys
 import unittest
+import uuid
+import responses
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -17,18 +19,30 @@ class TestApiClient(UploadTestCase):
     def setUp(self):
         super(self.__class__, self).setUp()
         config = UploadConfig()
-        config._config.upload.preprod_api_url_template = "https://prefix.{deployment_stage}.suffix"
-        config._config.upload.production_api_url = "https://prefix.suffix"
+        config._config.upload.preprod_api_url_template = "https://prefix.{deployment_stage}.suffix/v1"
+        config._config.upload.production_api_url = "https://prefix.suffix/v1"
         config.save()
 
     def test_api_base_is_set_correctly_for_preprod(self):
 
         client = ApiClient(deployment_stage="somestage")
-        self.assertEqual("https://prefix.somestage.suffix", client.api_url_base)
+        self.assertEqual("https://prefix.somestage.suffix/v1", client.api_url_base)
 
     def test_api_base_is_set_correctly_for_prod(self):
         client = ApiClient(deployment_stage="prod")
-        self.assertEqual("https://prefix.suffix", client.api_url_base)
+        self.assertEqual("https://prefix.suffix/v1", client.api_url_base)
+
+    @responses.activate
+    def test_file_upload_notification(self):
+        area_id = str(uuid.uuid4())
+        client = ApiClient(deployment_stage="test")
+        self.simulate_file_upload_notification_api(area_uuid=area_id,
+                                                   filename="filename123",
+                                                   api_host="prefix.test.suffix")
+
+        response = client.file_upload_notification(area_uuid=area_id, filename="filename123")
+
+        self.assertEqual(response.status_code, 202)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR accomplishes bullet # 2 `Update hca cli to call post /uuid/filename after file upload` in https://github.com/HumanCellAtlas/upload-service/issues/227. After the api change in # 1 is promoted up through all environments, this should be merged in and a new lib version cut. Then bullet # 3 can be merged in and promoted up through upload environments