### PR TITLE
Apply log level to requests and urllib3

### DIFF
--- a/hca/cli.py
+++ b/hca/cli.py
@@ -72,6 +72,10 @@ def main(args=None):
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=logging.ERROR)
     logger.setLevel(parsed_args.log_level)
+
+    logging.getLogger("urllib3").setLevel(parsed_args.log_level)
+    logging.getLogger("requests").setLevel(parsed_args.log_level)
+
     try:
         result = parsed_args.entry_point(parsed_args)
     except Exception as e:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -110,13 +110,13 @@ from .fs_helper import FSHelper as fs
 
 
 class RetryPolicy(retry.Retry):
-    def __init__(self, retry_after_status_codes={301}, **kwargs):
-        super(RetryPolicy, self).__init__(**kwargs)
+    def __init__(self, retry_after_status_codes={301}, *args, **kwargs):
+        super(RetryPolicy, self).__init__(*args, **kwargs)
         self.RETRY_AFTER_STATUS_CODES = frozenset(retry_after_status_codes | retry.Retry.RETRY_AFTER_STATUS_CODES)
 
-    def increment(self, **kwargs):
+    def increment(self, *args, **kwargs):
         try:
-            return super(RetryPolicy, self).increment(**kwargs)
+            return super(RetryPolicy, self).increment(*args, **kwargs)
         except MaxRetryError:
             raise SwaggerAPIMaxRetry(response=kwargs['response'])
 

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -120,6 +120,7 @@ class RetryPolicy(retry.Retry):
         except MaxRetryError:
             raise SwaggerAPIMaxRetry(response=kwargs['response'])
 
+
 class _ClientMethodFactory(object):
 
     def __init__(self, client, parameters, path_parameters, http_method, method_name, method_data, body_props):

--- a/hca/util/exceptions.py
+++ b/hca/util/exceptions.py
@@ -25,7 +25,6 @@ class SwaggerAPIException(HTTPError):
                 return "{}: {} (HTTP {}). Details:\n{}".format(self.reason, self.title, self.code, self.stacktrace)
             return "{}: {} (HTTP {}). Details:\n{}".format(self.reason, self.title, self.code, self.response.text)
         return "{}, code {}".format(self.response.reason, self.response.status_code)
-    
 
 class SwaggerClientInternalError(Exception):
     pass

--- a/hca/util/exceptions.py
+++ b/hca/util/exceptions.py
@@ -26,5 +26,11 @@ class SwaggerAPIException(HTTPError):
             return "{}: {} (HTTP {}). Details:\n{}".format(self.reason, self.title, self.code, self.response.text)
         return "{}, code {}".format(self.response.reason, self.response.status_code)
 
+class SwaggerAPIMaxRetry(SwaggerAPIException):
+    """
+    Exception raised when the max number of retries is exceeded.
+    """
+    pass
+
 class SwaggerClientInternalError(Exception):
     pass

--- a/hca/util/exceptions.py
+++ b/hca/util/exceptions.py
@@ -25,12 +25,7 @@ class SwaggerAPIException(HTTPError):
                 return "{}: {} (HTTP {}). Details:\n{}".format(self.reason, self.title, self.code, self.stacktrace)
             return "{}: {} (HTTP {}). Details:\n{}".format(self.reason, self.title, self.code, self.response.text)
         return "{}, code {}".format(self.response.reason, self.response.status_code)
-
-class SwaggerAPIMaxRetry(SwaggerAPIException):
-    """
-    Exception raised when the max number of retries is exceeded.
-    """
-    pass
+    
 
 class SwaggerClientInternalError(Exception):
     pass


### PR DESCRIPTION
This will allow us to return information regarding requests and request retries when the log level is set to warning or higher.

Partial fix for https://github.com/HumanCellAtlas/dcp-cli/issues/172