### PR TITLE
enable file copy from s3 to upload area

### DIFF
--- a/hca/upload/s3_agent.py
+++ b/hca/upload/s3_agent.py
@@ -67,6 +67,8 @@ class S3Agent:
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
     def copy_s3_file(self, s3_path, target_bucket, target_key, content_type, report_progress=False):
+        # Here we are using s3's managed copy to allow for s3 to s3 file upload
+        # We override any original metadata or content types
         s3_path_split = s3_path.replace("s3://", "").split("/", 1)
         source_bucket = s3_path_split[0]
         source_key = s3_path_split[1]

--- a/hca/upload/s3_agent.py
+++ b/hca/upload/s3_agent.py
@@ -80,12 +80,13 @@ class S3Agent:
             'CopySource': copy_source,
             'ExtraArgs': {
                 'ContentType': content_type,
-                'ACL': 'bucket-owner-full-control',
+                'MetadataDirective': 'REPLACE',
+                'ACL': 'bucket-owner-full-control'
             },
             'Config': self.transfer_config(file_size),
             'SourceClient': self.source_s3_client,
             'Bucket': target_bucket,
-            'Key': target_key,
+            'Key': target_key
         }
         if report_progress:
             upload_args['Callback'] = self.upload_progress_callback

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -143,7 +143,7 @@ class UploadArea:
                 target_key = "%s/%s" % (self.uuid, target_filename or file_name)
                 mime_type = mimetypes.guess_type(file_path)[0]
                 content_type = "{0}; dcp_type=data".format(mime_type)
-                self.s3agent.copy_s3_file(file_path, target_bucket, target_key, dcp_type,
+                self.s3agent.copy_s3_file(file_path, target_bucket, target_key, content_type,
                                           report_progress=report_progress)
             else:
                 target_key = "%s/%s" % (self.uuid, target_filename or os.path.basename(file_path))

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -1,5 +1,6 @@
 import os
 import re
+import mimetypes
 
 from dcplib.media_types import DcpMediaType
 
@@ -100,12 +101,14 @@ class UploadArea:
             for file_info in files_info:
                 yield file_info
 
-    def upload_files(self, file_paths, dcp_type="data", target_filename=None, use_transfer_acceleration=True,
-                     report_progress=False):
+    def upload_files(self, file_paths, file_size_sum, dcp_type="data", target_filename=None,
+                     use_transfer_acceleration=True, report_progress=False):
         """
         A function that takes in a list of file paths and other optional args for parallel file upload
         """
-        self._setup_s3_agent_for_file_upload(file_paths=file_paths, use_transfer_acceleration=use_transfer_acceleration)
+        self._setup_s3_agent_for_file_upload(file_count=len(file_paths),
+                                             file_size_sum=file_size_sum,
+                                             use_transfer_acceleration=use_transfer_acceleration)
         pool = ThreadPool()
         if report_progress:
             print("\nStarting upload of %s files to upload area %s" % (len(file_paths), self.uuid))
@@ -126,20 +129,28 @@ class UploadArea:
                 error += "\nPlease retry or contact an hca administrator at data-help@humancellatlas.org for help.\n"
                 raise UploadException(error)
 
-    def _setup_s3_agent_for_file_upload(self, file_paths=[], use_transfer_acceleration=True):
+    def _setup_s3_agent_for_file_upload(self, file_count=0, file_size_sum=0, use_transfer_acceleration=True):
         creds_provider = CredentialsManager(upload_area=self)
         self.s3agent = S3Agent(credentials_provider=creds_provider, transfer_acceleration=use_transfer_acceleration)
-        file_size_sum = sum(os.path.getsize(path) for path in file_paths)
-        file_count = len(file_paths)
         self.s3agent.set_s3_agent_variables_for_batch_file_upload(file_count=file_count, file_size_sum=file_size_sum)
 
     def _upload_file(self, file_path=None, dcp_type="data", target_filename=None, use_transfer_acceleration=True,
                      report_progress=False):
         try:
-            file_s3_key = "%s/%s" % (self.uuid, target_filename or os.path.basename(file_path))
-            content_type = str(DcpMediaType.from_file(file_path, dcp_type))
-            self.s3agent.upload_file(file_path, self.uri.bucket_name, file_s3_key, content_type, report_progress=report_progress)
+            target_bucket = self.uri.bucket_name
+            if file_path.startswith("s3://"):
+                file_name = file_path.split('/')[-1]
+                target_key = "%s/%s" % (self.uuid, target_filename or file_name)
+                mime_type = mimetypes.guess_type(file_path)[0]
+                content_type = "{0}; dcp_type=data".format(mime_type)
+                self.s3agent.copy_s3_file(file_path, target_bucket, target_key, dcp_type,
+                                          report_progress=report_progress)
+            else:
+                target_key = "%s/%s" % (self.uuid, target_filename or os.path.basename(file_path))
+                content_type = str(DcpMediaType.from_file(file_path, dcp_type))
+                self.s3agent.upload_local_file(file_path, target_bucket, target_key, content_type,
+                                               report_progress=report_progress)
             self.s3agent.file_upload_completed_count += 1
-            print("Upload complete of %s to upload area %s" % (file_path, file_s3_key))
+            print("Upload complete of %s to upload area %s" % (file_path, self.uri))
         except Exception as e:
             self.s3agent.failed_uploads[file_path] = e

--- a/test/integration/upload/cli/test_upload.py
+++ b/test/integration/upload/cli/test_upload.py
@@ -119,6 +119,23 @@ class TestUploadCliUploadCommand(UploadTestCase):
         self.assertEqual(total_fize_size, 1078)
 
     @responses.activate
+    def test_load_file_paths_from_upload_path_with_s3_input(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
+        partial_obj_key = "{0}/LIC".format(area_path)
+        complete_obj_key = "{0}/LICENSE".format(area_path)
+
+        upload_command._load_file_paths_from_upload_path(args, partial_obj_key)
+
+        self.assertEqual(True, complete_obj_key in upload_command.file_paths)
+        self.assertEqual(3, len(upload_command.file_paths))
+        self.assertEqual(upload_command.file_size_sum, 6439)
+
+    @responses.activate
     def test_retrieve_files_list_and_size_sum_tuple_from_s3_path_with_complete_obj_key(self):
         files = ['LICENSE', 'README.rst']
         args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,

--- a/test/integration/upload/cli/test_upload.py
+++ b/test/integration/upload/cli/test_upload.py
@@ -44,6 +44,97 @@ class TestUploadCliUploadCommand(UploadTestCase):
             self.assertEqual(obj.get()['Body'].read(), expected_contents)
 
     @responses.activate
+    def test_parse_s3_path_with_no_prefix(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        s3_path_with_no_prefix = "s3://fake-bucket"
+
+        bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
+
+        self.assertEqual(bucket, "fake-bucket")
+        self.assertEqual(prefix, "")
+
+    @responses.activate
+    def test_parse_s3_path_with_dir_prefix(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        s3_path_with_no_prefix = "s3://fake-bucket/fake-dir/"
+
+        bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
+
+        self.assertEqual(bucket, "fake-bucket")
+        self.assertEqual(prefix, "fake-dir/")
+
+    @responses.activate
+    def test_parse_s3_path_with_obj_prefix(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        s3_path_with_no_prefix = "s3://fake-bucket/fake-dir/fake-obj"
+
+        bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
+
+        self.assertEqual(bucket, "fake-bucket")
+        self.assertEqual(prefix, "fake-dir/fake-obj")
+
+    @responses.activate
+    def test_retrieve_files_list_and_size_sum_tuple_from_s3_path_with_dir_key(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        area_s3_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
+
+        s3_file_paths, total_fize_size = upload_command._retrieve_files_list_and_size_sum_tuple_from_s3_path(area_s3_path)
+
+        for file in files:
+            file_key = "{0}/{1}".format(area_s3_path, file)
+            self.assertEqual(True, file_key in s3_file_paths)
+        self.assertEqual(total_fize_size, 5361)
+
+    @responses.activate
+    def test_retrieve_files_list_and_size_sum_tuple_from_s3_path_with_partial_obj_key(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
+        partial_obj_key = "{0}/LIC".format(area_path)
+        complete_obj_key = "{0}/LICENSE".format(area_path)
+
+        s3_file_paths, total_fize_size = upload_command._retrieve_files_list_and_size_sum_tuple_from_s3_path(partial_obj_key)
+
+        self.assertEqual(True, complete_obj_key in s3_file_paths)
+        self.assertEqual(1, len(s3_file_paths))
+        self.assertEqual(total_fize_size, 1078)
+
+    @responses.activate
+    def test_retrieve_files_list_and_size_sum_tuple_from_s3_path_with_complete_obj_key(self):
+        files = ['LICENSE', 'README.rst']
+        args = Namespace(upload_paths=files, target_filename=None, no_transfer_acceleration=False,
+                         dcp_type=None, quiet=True, file_extension=None)
+        self.simulate_credentials_api(area_uuid=self.area.uuid)
+        upload_command = UploadCommand(args)
+        area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
+        complete_obj_key = "{0}/LICENSE".format(area_path)
+
+        s3_file_paths, total_fize_size = upload_command._retrieve_files_list_and_size_sum_tuple_from_s3_path(complete_obj_key)
+
+        self.assertEqual(True, complete_obj_key in s3_file_paths)
+        self.assertEqual(1, len(s3_file_paths))
+        self.assertEqual(total_fize_size, 1078)
+
+    @responses.activate
     def test_upload_with_dcp_type_option(self):
 
         args = Namespace(upload_paths=['LICENSE'], target_filename=None, no_transfer_acceleration=False, quiet=True, file_extension=None)
@@ -62,7 +153,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
     def test_no_transfer_acceleration_option_sets_up_botocore_config_correctly(self):
         import botocore
 
-        with patch('hca.upload.s3_agent.S3Agent.upload_file'), \
+        with patch('hca.upload.s3_agent.S3Agent.upload_local_file'), \
             patch('hca.upload.s3_agent.Config', new=Mock(wraps=botocore.config.Config)) as mock_config:
 
             args = Namespace(upload_paths=['LICENSE'], target_filename=None, quiet=True, file_extension=None)

--- a/test/integration/upload/python_bindings/test_upload_file.py
+++ b/test/integration/upload/python_bindings/test_upload_file.py
@@ -98,5 +98,16 @@ class TestUploadFileUpload(UploadTestCase):
         write_to_terminal = self.area.s3agent.should_write_to_terminal()
         self.assertEqual(write_to_terminal, True)
 
+    @responses.activate
+    def test_determine_s3_file_content_type(self):
+        content_type_one = self.area._determine_s3_file_content_type("s3://bucket/file.json")
+        content_type_two = self.area._determine_s3_file_content_type("s3://bucket/file.fastq.gz")
+        content_type_three = self.area._determine_s3_file_content_type("s3://bucket/file.pdf")
+
+        self.assertEqual(content_type_one, "application/json; dcp-type=data")
+        self.assertEqual(content_type_two, "application/gzip; dcp-type=data")
+        self.assertEqual(content_type_three, "application/pdf; dcp-type=data")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/integration/upload/python_bindings/test_upload_file.py
+++ b/test/integration/upload/python_bindings/test_upload_file.py
@@ -50,7 +50,7 @@ class TestUploadFileUpload(UploadTestCase):
     def test_s3_agent_setup_for_single_file_upload(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
         file_paths = ["LICENSE"]
-        self.area._setup_s3_agent_for_file_upload(file_paths=file_paths)
+        self.area._setup_s3_agent_for_file_upload(file_size_sum=1078, file_count=1)
         self.assertEqual(self.area.s3agent.file_count, 1)
         self.assertEqual(self.area.s3agent.file_size_sum, 1078)
         self.assertEqual(self.area.s3agent.file_upload_completed_count, 0)
@@ -59,8 +59,7 @@ class TestUploadFileUpload(UploadTestCase):
     @responses.activate
     def test_s3_agent_setup_for_multiple_file_upload(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        file_paths = ["LICENSE", "LICENSE"]
-        self.area._setup_s3_agent_for_file_upload(file_paths=file_paths)
+        self.area._setup_s3_agent_for_file_upload(file_size_sum=2156, file_count=2)
         self.assertEqual(self.area.s3agent.file_count, 2)
         self.assertEqual(self.area.s3agent.file_size_sum, 2156)
         self.assertEqual(self.area.s3agent.file_upload_completed_count, 0)
@@ -70,7 +69,7 @@ class TestUploadFileUpload(UploadTestCase):
     def test_s3_agent_stats_update_for_single_file_upload(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
         file_paths = ["LICENSE"]
-        self.area.upload_files(file_paths=file_paths)
+        self.area.upload_files(file_paths=file_paths, file_size_sum=1078)
         self.assertEqual(self.area.s3agent.file_count, 1)
         self.assertEqual(self.area.s3agent.file_size_sum, 1078)
         self.assertEqual(self.area.s3agent.file_upload_completed_count, 1)
@@ -79,15 +78,14 @@ class TestUploadFileUpload(UploadTestCase):
     def test_s3_agent_stats_update_for_multiple_file_upload(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
         file_paths = ["LICENSE", "LICENSE"]
-        self.area.upload_files(file_paths=file_paths)
+        self.area.upload_files(file_paths=file_paths, file_size_sum=2156)
         self.assertEqual(self.area.s3agent.file_count, 2)
         self.assertEqual(self.area.s3agent.file_size_sum, 2156)
         self.assertEqual(self.area.s3agent.file_upload_completed_count, 2)
 
     @responses.activate
     def test_s3_agent_should_write_to_terminal(self):
-        file_paths = ["LICENSE", "LICENSE"]
-        self.area._setup_s3_agent_for_file_upload(file_paths=file_paths)
+        self.area._setup_s3_agent_for_file_upload(file_size_sum=2156, file_count=2)
         below_threshold_bytes = WRITE_PERCENT_THRESHOLD / 100.0 * self.area.s3agent.file_size_sum / 2
         above_threshold_bytes = WRITE_PERCENT_THRESHOLD / 100.0 * self.area.s3agent.file_size_sum * 2
         self.assertEqual(self.area.s3agent.file_size_sum, 2156)


### PR DESCRIPTION
This PR allows for copy into an upload area from aws s3 as defined in ticket #231 and is related to https://github.com/HumanCellAtlas/dcp-cli/pull/217/files. With the correct policies in place, this enables cross account file transfer.