### PR TITLE
reduce threads running on upload and reraise error from tenacity on upload methods

### DIFF
--- a/hca/upload/api_client.py
+++ b/hca/upload/api_client.py
@@ -33,7 +33,7 @@ class ApiClient:
                     content=response.content))
         return response.json()
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(3))
     def file_upload_notification(self, area_uuid, filename):
         url = "{api_url_base}/area/{area_uuid}/{filename}".format(api_url_base=self.api_url_base,
                                                                   area_uuid=area_uuid,

--- a/hca/upload/s3_agent.py
+++ b/hca/upload/s3_agent.py
@@ -65,7 +65,7 @@ class S3Agent:
             write_to_terminal = True
         return write_to_terminal
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(3))
     def copy_s3_file(self, s3_path, target_bucket, target_key, content_type, report_progress=False):
         # Here we are using s3's managed copy to allow for s3 to s3 file upload
         # We override any original metadata or content types
@@ -94,7 +94,7 @@ class S3Agent:
             upload_args['Callback'] = self.upload_progress_callback
         self.target_s3.meta.client.copy(**upload_args)
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    @retry(reraise=True, wait=wait_fixed(2), stop=stop_after_attempt(3))
     def upload_local_file(self, local_path, target_bucket, target_key, content_type, report_progress=False):
         file_size = os.path.getsize(local_path)
         bucket = self.target_s3.Bucket(target_bucket)

--- a/hca/util/pool.py
+++ b/hca/util/pool.py
@@ -10,7 +10,7 @@ else:
 
 """Based on https://askubuntu.com/questions/668538/cores-vs-threads-how-many-threads-should-i-run-on-this-machine
         and https://github.com/bloomreach/s4cmd/blob/master/s4cmd.py#L121."""
-DEFAULT_THREAD_COUNT = multiprocessing.cpu_count() * 4
+DEFAULT_THREAD_COUNT = multiprocessing.cpu_count() * 2
 
 
 class Worker(Thread):


### PR DESCRIPTION
Users have reported issues with too many threads running. This fix reduces the number of threads running as a relationship with cpu count. This PR also adds reraise=True to all retries to ensure all errors are logged appropriately.