### PR TITLE
[Easy] Temporary fix to allow POST requests to be retried.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -115,9 +115,15 @@ from .fs_helper import FSHelper as fs
 
 
 class RetryPolicy(retry.Retry):
-    def __init__(self, retry_after_status_codes={301}, *args, **kwargs):
+    DEFAULT_METHOD_WHITELIST = frozenset(['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'POST'])
+
+    def __init__(self,
+                 retry_after_status_codes={301, 500},
+                 method_whitelist=DEFAULT_METHOD_WHITELIST,
+                 *args, **kwargs):
         super(RetryPolicy, self).__init__(*args, **kwargs)
         self.RETRY_AFTER_STATUS_CODES = frozenset(retry_after_status_codes | retry.Retry.RETRY_AFTER_STATUS_CODES)
+        self.method_whitelist = method_whitelist  # methods not on this list will not be retried
 
     def increment(self, *args, **kwargs):
         _retry = super(RetryPolicy, self).increment(*args, **kwargs)

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -118,7 +118,7 @@ class RetryPolicy(retry.Retry):
     DEFAULT_METHOD_WHITELIST = frozenset(['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'POST'])
 
     def __init__(self,
-                 retry_after_status_codes={301, 500},
+                 retry_after_status_codes={301},
                  method_whitelist=DEFAULT_METHOD_WHITELIST,
                  *args, **kwargs):
         super(RetryPolicy, self).__init__(*args, **kwargs)

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -143,6 +143,8 @@ class _ClientMethodFactory(object):
         the swagger is updated and changes applied to prod.  In the meantime, this function will add
         retries specifically for POST search (and any other POST requests will not be retried).
         """
+        # TODO: Revert this PR as soon as the appropriate swagger definitions have percolated up
+        # to prod and merged; see https://github.com/HumanCellAtlas/data-store/pull/1961
         status_code = 500
         if '/v1/search' in url:
             retry_count = 10


### PR DESCRIPTION
Addresses #222 .

Iterate wasn't retrying on this:
```
from hca import HCAConfig
from hca.dss import DSSClient

hca_config = HCAConfig()
hca_config['DSSClient'].swagger_url = f'https://dss.dev.data.humancellatlas.org/v1/swagger.json'
dss = DSSClient(config=hca_config)
print(len(list(dss.post_search.iterate(es_query={}, replica="aws"))))
```
And so would break on a 500, even though we should retry on 500 errors.

That's because `urllib3.util.retry` doesn't retry on POST requests.  This fixes that temporarily.

The longer term solution is here: https://github.com/HumanCellAtlas/data-store/pull/1961  See comments there for follow-up steps.

We'll have to wait a month+ for that to percolate up to `prod` though, so this is a stop-gap in the meantime.