### PR TITLE
using google.auth.default to get service or user credentials.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -356,16 +356,10 @@ class SwaggerClient(object):
 
     def _get_oauth_token_from_service_account_credentials(self):
         scopes = ["https://www.googleapis.com/auth/userinfo.email"]
-        # assert 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ
         from google.auth.transport.requests import Request as GoogleAuthRequest
         from google.auth import default as AccountCredentials
         logger.info("Found GOOGLE_APPLICATION_CREDENTIALS environment variable. "
                     "Using service account credentials for authentication.")
-        # service_account_credentials_filename = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
-
-        # if not os.path.isfile(service_account_credentials_filename):
-        #     msg = 'File "{}" referenced by the GOOGLE_APPLICATION_CREDENTIALS environment variable does not exist'
-        #     raise Exception(msg.format(service_account_credentials_filename))
 
         credentials, _ = AccountCredentials(scopes=scopes)
         r = GoogleAuthRequest()

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -356,21 +356,18 @@ class SwaggerClient(object):
 
     def _get_oauth_token_from_service_account_credentials(self):
         scopes = ["https://www.googleapis.com/auth/userinfo.email"]
-        assert 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ
+        # assert 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ
         from google.auth.transport.requests import Request as GoogleAuthRequest
-        from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+        from google.auth import default as AccountCredentials
         logger.info("Found GOOGLE_APPLICATION_CREDENTIALS environment variable. "
                     "Using service account credentials for authentication.")
-        service_account_credentials_filename = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
+        # service_account_credentials_filename = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
 
-        if not os.path.isfile(service_account_credentials_filename):
-            msg = 'File "{}" referenced by the GOOGLE_APPLICATION_CREDENTIALS environment variable does not exist'
-            raise Exception(msg.format(service_account_credentials_filename))
+        # if not os.path.isfile(service_account_credentials_filename):
+        #     msg = 'File "{}" referenced by the GOOGLE_APPLICATION_CREDENTIALS environment variable does not exist'
+        #     raise Exception(msg.format(service_account_credentials_filename))
 
-        credentials = ServiceAccountCredentials.from_service_account_file(
-            service_account_credentials_filename,
-            scopes=scopes
-        )
+        credentials, _ = AccountCredentials(scopes=scopes)
         r = GoogleAuthRequest()
         credentials.refresh(r)
         r.session.close()


### PR DESCRIPTION
install gcloud
`gcloud auth application-default login`


``` python
>>> from hca.dss import DSSClient
>>> client = DSSClient()
>>> client._get_oauth_token_from_service_account_credentials()
/home/dcp/dcp-cli/venv/lib/python3.6/site-packages/google/auth/_default.py:66: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
('ya29.GlvFBlXS-_lIVebomOSd6yWC_9k9l9Br4wOkQaruK5Te5o65Uq_eKAKMAkwVNKBCAViyno-CReIDEA9v3CxGBy2DeDQ2XoGDGfkATz9h0tyDtcqARRr44ZeXO-kb', datetime.datetime(2019, 3, 7, 22, 20, 0, 92355))
```
connects to #258