### PR TITLE
allow for not providing slashes when selecting upload area

### DIFF
--- a/hca/upload/cli/select_command.py
+++ b/hca/upload/cli/select_command.py
@@ -24,6 +24,8 @@ class SelectCommand(UploadCLICommand):
             self._select_area_by_alias(args.uri_or_alias)
 
     def _save_and_select_area_by_uri(self, uri_string):
+        if not uri_string.endswith('/'):
+            uri_string += '/'
         area = UploadArea(uri=uri_string)
         area.select()
         print("Upload area %s selected." % area.uuid)

--- a/test/integration/upload/cli/test_select.py
+++ b/test/integration/upload/cli/test_select.py
@@ -22,18 +22,29 @@ class TestUploadCliSelectCommand(UploadTestCase):
 
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.area_uuid = str(uuid.uuid4())
-        self.uri = "s3://org-humancellatlas-upload-test/{}/".format(self.area_uuid)
+        self._area_uuid = str(uuid.uuid4())
+        self._uri = "s3://org-humancellatlas-upload-test/{}/".format(self._area_uuid)
 
     def test_when_given_an_unrecognized_urn_it_stores_it_in_upload_area_list_and_sets_it_as_current_area(self):
         with CapturingIO('stdout') as stdout:
-            args = Namespace(uri_or_alias=self.uri)
+            args = Namespace(uri_or_alias=self._uri)
             SelectCommand(args)
 
         config = hca.get_config()
-        self.assertIn(self.area_uuid, config.upload.areas)
-        self.assertEqual(self.uri, config.upload.areas[self.area_uuid]['uri'])
-        self.assertEqual(self.area_uuid, config.upload.current_area)
+        self.assertIn(self._area_uuid, config.upload.areas)
+        self.assertEqual(self._uri, config.upload.areas[self._area_uuid]['uri'])
+        self.assertEqual(self._area_uuid, config.upload.current_area)
+
+    def test_when_given_an_unrecognized_uri_without_slash_it_sets_it_as_current_area(self):
+        uri_without_slash = "s3://org-humancellatlas-upload-test/{}".format(self._area_uuid)
+        with CapturingIO('stdout') as stdout:
+            args = Namespace(uri_or_alias=uri_without_slash)
+            SelectCommand(args)
+
+        config = hca.get_config()
+        self.assertIn(self._area_uuid, config.upload.areas)
+        self.assertEqual(self._uri, config.upload.areas[self._area_uuid]['uri'])
+        self.assertEqual(self._area_uuid, config.upload.current_area)
 
     def test_when_given_a_uri_it_prints_an_alias(self):
         config = hca.get_config()


### PR DESCRIPTION
This is for ticket https://github.com/HumanCellAtlas/upload-service/issues/326. This allows users to pass in upload area uri without a slash when selecting it via hca cli