### PR TITLE
[Easy] Centralize SECURITY.md, and delete security.txt.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,11 @@ Bugs
 ~~~~
 Please report bugs, issues, feature requests, etc. on `GitHub <https://github.com/HumanCellAtlas/dcp-cli/issues>`_.
 
+
+Security Policy
+---------------
+See our [Security Policy](https://github.com/HumanCellAtlas/dcp/blob/master/SECURITY.md).
+
 License
 -------
 Licensed under the terms of the `MIT License <https://opensource.org/licenses/MIT>`_.

--- a/security.txt
+++ b/security.txt
@@ -1,3 +1,0 @@
-If you'd like to report a security issue please contact us.
-
-Contact: security-leads@data.humancellatlas.org


### PR DESCRIPTION
Links to the centralized policy at dcp, based on the conversation here: HumanCellAtlas/dcp#274 .