### PR TITLE
Catch exception if link exists

### DIFF
--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -1,3 +1,4 @@
+import errno
 import os
 
 import platform
@@ -52,4 +53,8 @@ def hardlink(source, link_name):
         if res == 0:
             raise ctypes.WinError()
     else:
-        os.link(source, link_name)
+        try:
+            os.link(source, link_name)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise


### PR DESCRIPTION
This was causing tests to fail for datastore (Sorry :disappointed:)