### PR TITLE
Allow download directory to be configurable

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -72,7 +72,7 @@ class DSSClient(SwaggerClient):
         super(DSSClient, self).__init__(*args, **kwargs)
         self.commands += [self.download, self.download_manifest, self.download_manifest_v2, self.upload]
 
-    def download(self, bundle_uuid, replica, version="", dest_name="",
+    def download(self, bundle_uuid, replica, version="", download_dir="",
                  metadata_files=('*',), data_files=('*',),
                  num_retries=10, min_delay_seconds=0.25):
         """
@@ -111,7 +111,7 @@ class DSSClient(SwaggerClient):
                                    for dss_file, task in self._download_tasks(bundle_uuid,
                                                                               replica,
                                                                               version,
-                                                                              dest_name,
+                                                                              download_dir,
                                                                               metadata_files,
                                                                               data_files,
                                                                               num_retries,
@@ -127,12 +127,15 @@ class DSSClient(SwaggerClient):
         if errors:
             raise RuntimeError('{} file(s) failed to download'.format(errors))
 
-    def _download_tasks(self, bundle_uuid, replica, version="", dest_name="",
-                        metadata_files=('*',), data_files=('*',),
-                        num_retries=10, min_delay_seconds=0.25):
-        if not dest_name:
-            dest_name = bundle_uuid
-
+    def _download_tasks(self,
+                        bundle_uuid,
+                        replica,
+                        version="",
+                        download_dir="",
+                        metadata_files=('*',),
+                        data_files=('*',),
+                        num_retries=10,
+                        min_delay_seconds=0.25):
         bundle = self.get_bundle(uuid=bundle_uuid, replica=replica, version=version if version else None)["bundle"]
 
         files = {}
@@ -152,7 +155,7 @@ class DSSClient(SwaggerClient):
         for file_ in files.values():
             dss_file = DSSFile.from_dss_bundle_response(file_, replica)
             filename = file_.get("name", dss_file.uuid)
-            walking_dir = dest_name
+            walking_dir = os.path.join(download_dir, bundle_uuid)
 
             globs = metadata_files if file_['indexed'] else data_files
             if not any(fnmatchcase(filename, glob) for glob in globs):
@@ -167,22 +170,24 @@ class DSSClient(SwaggerClient):
             logger.info("File %s: Retrieving...", filename)
             file_path = os.path.join(walking_dir, filename_base)
             yield dss_file, functools.partial(self._download_and_link_to_filestore,
+                                              download_dir,
                                               dss_file,
                                               file_path,
                                               num_retries=num_retries,
                                               min_delay_seconds=min_delay_seconds)
 
-    def _download_and_link_to_filestore(self, dss_file, file_path, num_retries, min_delay_seconds):
-        file_store_path = self._download_to_filestore(dss_file,
+    def _download_and_link_to_filestore(self, download_dir, dss_file, file_path, num_retries, min_delay_seconds):
+        file_store_path = self._download_to_filestore(download_dir,
+                                                      dss_file,
                                                       num_retries=num_retries,
                                                       min_delay_seconds=min_delay_seconds)
         hardlink(file_store_path, file_path)
 
-    def _download_to_filestore(self, dss_file, num_retries=10, min_delay_seconds=0.25):
+    def _download_to_filestore(self, download_dir, dss_file, num_retries=10, min_delay_seconds=0.25):
         """
         Attempt to download the data and save it in the 'filestore' location dictated by self._file_path()
         """
-        dest_path = self._file_path(dss_file.sha256)
+        dest_path = self._file_path(dss_file.sha256, download_dir)
         if os.path.exists(dest_path):
             logger.info("Skipping download of '%s' because it already exists at '%s'.", dss_file.name, dest_path)
         else:
@@ -286,15 +291,16 @@ class DSSClient(SwaggerClient):
         return hasher.hexdigest()
 
     @classmethod
-    def _file_path(cls, checksum):
+    def _file_path(cls, checksum, download_dir):
         """
         returns a file's relative local path based on the nesting parameters and the files hash
         :param checksum: a string checksum
+        :param download_dir: root directory for filestore
         :return: relative Path object
         """
         checksum = checksum.lower()
         file_prefix = '_'.join(['files'] + list(map(str, cls.DIRECTORY_NAME_LENGTHS)))
-        path_pieces = ['.hca', 'v2', file_prefix]
+        path_pieces = [download_dir, '.hca', 'v2', file_prefix]
         checksum_index = 0
         assert(sum(cls.DIRECTORY_NAME_LENGTHS) <= len(checksum))
         for prefix_length in cls.DIRECTORY_NAME_LENGTHS:
@@ -311,7 +317,7 @@ class DSSClient(SwaggerClient):
             reader = csv.DictReader(f, delimiter=delimiter, quoting=csv.QUOTE_NONE)
             return reader.fieldnames, list(reader)
 
-    def _write_output_manifest(self, manifest):
+    def _write_output_manifest(self, manifest, filestore_root):
         """
         Adds the file path column to the manifest and writes the copy to the current directory. If the original manifest
         is in the current directory it is overwritten with a warning.
@@ -325,7 +331,7 @@ class DSSClient(SwaggerClient):
             writer = csv.DictWriter(f, fieldnames, delimiter=delimiter, quoting=csv.QUOTE_NONE)
             writer.writeheader()
             for row in source_manifest:
-                row['file_path'] = self._file_path(row['file_sha256'])
+                row['file_path'] = self._file_path(row['file_sha256'], filestore_root)
                 writer.writerow(row)
             if os.path.isfile(output):
                 logger.warning('Overwriting manifest %s', output)
@@ -333,7 +339,8 @@ class DSSClient(SwaggerClient):
 
     def download_manifest_v2(self, manifest, replica,
                              num_retries=10,
-                             min_delay_seconds=0.25):
+                             min_delay_seconds=0.25,
+                             download_dir='.'):
         """
         Process the given manifest file in TSV (tab-separated values) format and download the files referenced by it.
         The files are downloaded in the version 2 format.
@@ -369,7 +376,7 @@ class DSSClient(SwaggerClient):
             futures_to_dss_file = {}
             for row in rows:
                 dss_file = DSSFile.from_manifest_row(row, replica)
-                future = executor.submit(self._download_to_filestore, dss_file,
+                future = executor.submit(self._download_to_filestore, download_dir, dss_file,
                                          num_retries=num_retries, min_delay_seconds=min_delay_seconds)
                 futures_to_dss_file[future] = dss_file
             for future in concurrent.futures.as_completed(futures_to_dss_file):
@@ -383,9 +390,9 @@ class DSSClient(SwaggerClient):
         if errors:
             raise RuntimeError('{} file(s) failed to download'.format(errors))
         else:
-            self._write_output_manifest(manifest)
+            self._write_output_manifest(manifest, download_dir)
 
-    def download_manifest(self, manifest, replica, num_retries=10, min_delay_seconds=0.25):
+    def download_manifest(self, manifest, replica, num_retries=10, min_delay_seconds=0.25, download_dir=''):
         """
         Process the given manifest file in TSV (tab-separated values) format and download the files referenced by it.
 
@@ -414,8 +421,9 @@ class DSSClient(SwaggerClient):
         file_errors = 0
         file_task, bundle_errors = self._download_manifest_tasks(manifest,
                                                                  replica,
-                                                                 num_retries=num_retries,
-                                                                 min_delay_seconds=min_delay_seconds)
+                                                                 num_retries,
+                                                                 min_delay_seconds,
+                                                                 download_dir)
         with concurrent.futures.ThreadPoolExecutor(self.threads) as executor:
             futures_to_dss_file = {executor.submit(task): dss_file
                                    for dss_file, task in file_task}
@@ -432,11 +440,11 @@ class DSSClient(SwaggerClient):
             file_error_str = '{} file(s) failed to download'.format(file_errors) if file_errors else ''
             raise RuntimeError(bundle_error_str + (' and ' if bundle_errors and file_errors else '') + file_error_str)
         else:
-            self._write_output_manifest(manifest)
+            self._write_output_manifest(manifest, download_dir)
             logger.info('Primary copies of the files have been downloaded to `.hca` and linked '
                         'into per-bundle subdirectories of the current directory.')
 
-    def _download_manifest_tasks(self, manifest, replica, num_retries, min_delay_seconds):
+    def _download_manifest_tasks(self, manifest, replica, num_retries, min_delay_seconds, download_dir):
         with open(manifest) as f:
             bundles = defaultdict(set)
             # unicode_literals is on so all strings are unicode. CSV wants a str so we need to jump through a hoop.
@@ -453,6 +461,7 @@ class DSSClient(SwaggerClient):
                 for task in self._download_tasks(bundle_uuid,
                                                  replica,
                                                  version=bundle_version,
+                                                 download_dir=download_dir,
                                                  data_files=data_globs,
                                                  num_retries=num_retries,
                                                  min_delay_seconds=min_delay_seconds):

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import errno
 from concurrent.futures import ThreadPoolExecutor
 import csv
 import datetime
@@ -72,7 +72,7 @@ class TestDssApi(unittest.TestCase):
         bundle_uuid = manifest['bundle_uuid']
         with self.subTest(bundle_uuid=bundle_uuid):
             with TemporaryDirectory() as dest_dir:
-                client.download(bundle_uuid=bundle_uuid, replica='aws', dest_name=dest_dir)
+                client.download(bundle_uuid=bundle_uuid, replica='aws', download_dir=dest_dir)
                 downloaded_file_names = [x.path for x in iter_paths(dest_dir)]
                 downloaded_file_paths = [object_name_builder(p, dest_dir) for p in downloaded_file_names]
                 self.assertEqual(uploaded_files.sort(), downloaded_file_paths.sort())
@@ -118,19 +118,29 @@ class TestDssApi(unittest.TestCase):
 
                     with TemporaryDirectory() as dest_dir:
                         client.download(bundle_uuid=bundle_uuid,
-                                        dest_name=dest_dir,
+                                        download_dir=dest_dir,
                                         replica="aws",
                                         data_files=data_globs,
                                         metadata_files=metadata_globs)
                         # Check that contents are the same
-                        downloaded_files = set(os.listdir(dest_dir))
+                        try:
+                            downloaded_files = set(os.listdir(os.path.join(dest_dir, bundle_uuid)))
+                        except OSError as e:
+                            if e.errno != errno.ENOENT:
+                                raise
+                            downloaded_files = set()
+                        if '.hca' in downloaded_files:
+                            # Since we set the download_dir for download, .hca dir will appear,
+                            # but only if globs are non-empty
+                            assert not all(glob in [(), ('',)] for glob in [metadata_globs, data_globs])
+                            downloaded_files.remove('.hca')
                         self.assertEqual(expect_downloaded_files, downloaded_files)
                         for file in downloaded_files:
                             manifest_entry = next(entry for entry in manifest['files'] if entry['name'] == file)
                             globs = metadata_globs if manifest_entry['indexed'] else data_globs
                             self.assertTrue(any(fnmatchcase(file, glob) for glob in globs))
                             uploaded_file = os.path.join(bundle_path, file)
-                            downloaded_file = os.path.join(dest_dir, file)
+                            downloaded_file = os.path.join(dest_dir, bundle_uuid, file)
                             self.assertTrue(filecmp.cmp(uploaded_file, downloaded_file, False))
 
     def test_python_manifest_download(self):
@@ -208,9 +218,9 @@ class TestDssApi(unittest.TestCase):
                 client = hca.dss.DSSClient()
                 bundle_output = client.upload(src_dir=src_dir, replica="aws", staging_bucket=self.staging_bucket)
 
-                client.download(bundle_output['bundle_uuid'], replica="aws", dest_name=dest_dir)
+                client.download(bundle_output['bundle_uuid'], replica="aws", download_dir=dest_dir)
 
-                downloaded_file = os.path.join(dest_dir, os.path.basename(fh.name))
+                downloaded_file = os.path.join(dest_dir, bundle_output['bundle_uuid'], os.path.basename(fh.name))
                 self.assertTrue(filecmp.cmp(fh.name, downloaded_file, False))
 
     def test_python_bindings(self):
@@ -221,7 +231,7 @@ class TestDssApi(unittest.TestCase):
         bundle_uuid = bundle_output['bundle_uuid']
 
         with TemporaryDirectory() as dest_dir:
-            client.download(bundle_uuid=bundle_output['bundle_uuid'], replica="aws", dest_name=dest_dir)
+            client.download(bundle_uuid=bundle_output['bundle_uuid'], replica="aws", download_dir=dest_dir)
 
         # Test get-files and head-files
         file_ = bundle_output['files'][0]

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -43,18 +43,12 @@ class TestDssCLI(unittest.TestCase):
                 with CapturingIO('stdout') as stdout_upload:
                     hca.cli.main(args=upload_args)
                 upload_res = json.loads(stdout_upload.captured())
-                for f in upload_res['files']:
-                    print(f)
-                    if f["name"] == filename:
-                        file_uuid = f['uuid']
-                        break
-
                 download_args = ['dss', 'download', '--bundle-uuid', upload_res['bundle_uuid'],
-                                 '--replica', replica, '--dest-name', dest_dir]
-                with CapturingIO('stdout') as stdout_download:
+                                 '--replica', replica, '--download-dir', dest_dir]
+                with CapturingIO('stdout'):
                     hca.cli.main(args=download_args)
 
-                with open(os.path.join(dest_dir, filename), 'rb') as download_data:
+                with open(os.path.join(dest_dir, upload_res['bundle_uuid'], filename), 'rb') as download_data:
                     download_content = download_data.read()
                 with open(file_path, "rb") as bytes_fh:
                     file_content = bytes_fh.read()


### PR DESCRIPTION
There are a couple goals here. The first is with respect to the failing
allspark tests. The issue seemed to be because the /tmp dir was in a
separate partition from the filestore and this caused linking to fail
when the dest_path option was specified. The sensible solution would be
to place the filestore root in the same directory as dest_path. But
dest_path was poorly named. So I changed it to download_dir. The other
download funcs could use something similar I ended up solving an
auxilary goal: adding a configurable download parameter all of the
download endpoints.

The download_dir option is currently undocumented because it will be
simpler to take care of during breaking API changes in #297