### PR TITLE
Confirm hard link location during download (fixes #298)

### DIFF
--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -58,3 +58,12 @@ def hardlink(source, link_name):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
+            else:
+                # It's possible that the user created a different file with the same name as the
+                # one we're trying to download. Thus we need to check the if the inode is different
+                # and raise an error in this case.
+                source_stat = os.stat(source)
+                dest_stat = os.stat(link_name)
+                # Check device first because different drives can have the same inode number
+                if source_stat.st_dev != dest_stat.st_dev or source_stat.st_ino != dest_stat.st_ino:
+                    raise

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -337,6 +337,16 @@ class TestManifestDownloadBundle(AbstractTestDSSClient):
     def test_download_dir_dot_dir(self):
         self._test_download_dir(os.path.join('.', 'a_nested_dir'))
 
+    @patch('hca.dss.DSSClient.get_bundle', side_effect=_fake_get_bundle)
+    @patch('hca.dss.DSSClient._download_file', side_effect=_fake_download_file)
+    def test_manifest_download_bad_file(self, _, __):
+        """
+        Ensure error is raised if a user created file has the same name as the one
+        we're trying to download.
+        """
+        _touch_file(os.path.join(self.manifest[1][0], self.manifest[1][3]))
+        self.assertRaises(RuntimeError, self.dss.download_manifest, self.manifest_file, 'aws')
+
     @unittest.skipIf(sys.version_info < (3,) and platform.system() == 'Windows',
                      'os.stat() returns dummy values with Python 2.7 on Windows')
     @patch('hca.dss.DSSClient.get_bundle', side_effect=_fake_get_bundle)


### PR DESCRIPTION
Files in the download directory should only link to the filestore. If a link already exists this change ensure that it links to the filestore and raises an error if it links somewhere else.