### PR TITLE
SwaggerClient: set max redirects to a high number

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -255,6 +255,7 @@ class SwaggerClient(object):
     # client or sometimes one and sometimes the other.
     #
     timeout_policy = timeout.Timeout(connect=20, read=40)
+    max_redirects = 1024
 
     def __init__(self, config=None, swagger_url=None, **session_kwargs):
         self.config = config or get_config()
@@ -347,6 +348,7 @@ class SwaggerClient(object):
     def get_session(self):
         if self._session is None:
             self._session = requests.Session(**self._session_kwargs)
+            self._session.max_redirects = self.max_redirects
             self._session.headers.update({"User-Agent": self.__class__.__name__})
             self._set_retry_policy(self._session)
         return self._session


### PR DESCRIPTION
This allows checkout service redirect loops and other just-in-time API
patterns to succeed over long timeframes.

With a 30 second polling loop (Retry-After delay), 1024 redirects is
is 8 hours, which may be too long for current practical situations,
but Glacier unarchivals may theoretically be in that timeframe.