### PR TITLE
Remove crcmod from direct dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ awscli>1.15.70
 boto3 > 1.8
 botocore>=1.12.13
 commonmark >= 0.7.4, < 0.8
-crcmod >= 1.7, < 2
 cryptography==2.3.1
 dcplib >= 1.3.2, < 2
 docutils >= 0.14, < 1


### PR DESCRIPTION
It is no longer in use.

- Eliminates a binary dependency with no Linux wheels available on PyPI
- The binary extension build process introduces non-reproducibility into the build
- Developers should use crc32c instead where needed