### PR TITLE
[easy] Enumerate collections.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -228,12 +228,15 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
         page = None
         while page is None or page.links.get("next", {}).get("url"):
             page = self._request(kwargs, url=page.links["next"]["url"] if page else None)
-            try:
-                for result in page.json()["results"]:
+            if page.json().get('results'):
+                for result in page.json()['results']:
                     yield result
-            except KeyError:
-                for file in page.json()["bundle"]["files"]:
+            elif page.json().get('bundle'):
+                for file in page.json()['bundle']['files']:
                     yield file
+            else:
+                for collection in page.json().get('collections'):
+                    yield collection
 
 
 class SwaggerClient(object):


### PR DESCRIPTION
Addresses:  #291

Allows this to work:
```
from hca import HCAConfig
from hca.dss import DSSClient

hca_config = HCAConfig()
hca_config['DSSClient'].swagger_url = f'https://dss.dev.data.humancellatlas.org/v1/swagger.json'
dss = DSSClient(config=hca_config)
for i in dss.get_collections.iterate():
    print(i)
```

Running this looks like:
```
(v3nv) quokka@qcore:~/dcp-cli$ python collection_enumeration_example.py
```
```
{'uuid': 'ff9f622c-6ddf-495b-8c82-9583377c7629', 'version': '2019-05-03T113550.779252Z'}
{'uuid': 'fae9cecc-f4e0-4194-9290-7165f02515db', 'version': '2019-05-03T113358.141322Z'}
{'uuid': 'efebea4b-0bc9-45b8-aee3-b600abf1453f', 'version': '2019-05-03T113356.965509Z'}
{'uuid': 'eb1b17d5-7255-4907-97a6-142e58608c47', 'version': '2019-05-03T113357.776915Z'}
```