### PR TITLE
Fix redirect logic when Retry-After is given with a 301 redirect

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -108,6 +108,7 @@ from urllib3.util import retry, timeout
 from jsonpointer import resolve_pointer
 from threading import Lock
 
+from dcplib.networking import Session
 
 from .. import get_config, logger
 from .compat import USING_PYTHON2, urljoin
@@ -118,15 +119,6 @@ from .fs_helper import FSHelper as fs
 """Based on https://askubuntu.com/questions/668538/cores-vs-threads-how-many-threads-should-i-run-on-this-machine
         and https://github.com/bloomreach/s4cmd/blob/master/s4cmd.py#L121."""
 DEFAULT_THREAD_COUNT = multiprocessing.cpu_count() * 2
-
-
-class Session(requests.Session):
-    def resolve_redirects(self, resp, req, **kwargs):
-        if self.get_redirect_target(resp) and "Retry-After" in resp.headers:
-            logger.warning("Waiting %ss before redirect per Retry-After header", resp.headers["Retry-After"])
-            resp.connection.max_retries.sleep_for_retry(resp.raw)
-        for rv in super(Session, self).resolve_redirects(resp, req, **kwargs):
-            yield rv
 
 
 class RetryPolicy(retry.Retry):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3 > 1.8
 botocore>=1.12.13
 commonmark >= 0.9.0, < 1
 cryptography==2.3.1
-dcplib >= 2.0.0, < 3
+dcplib >= 2.0.2, < 3
 docutils >= 0.14, < 1
 google-auth >= 1.0.2, < 2
 google-auth-oauthlib >= 0.1, < 2


### PR DESCRIPTION
Fixes #337 

This is confusing and takes a while to figure out, but I think I've got it fixed.

There is a stack of libraries (requests->urllib3->httplib) handling HTTP requests.
- [urllib3.connectionpool.HTTPConnectionPool.urlopen](https://github.com/urllib3/urllib3/blob/master/src/urllib3/connectionpool.py#L449) has a (recursive) loop for handling retries for error responses (this is what urllib3.util.retry.Retry/max_retries configures).
- urllib3 also has code in this function for handling redirects; however, when used through requests, this logic is disabled.
- Instead, the logic in [requests.sessions.SessionRedirectMixin.resolve_redirects](https://github.com/kennethreitz/requests/blob/master/requests/sessions.py#L143) is used.

When I first configured this, I erroneously assumed that the logic in urllib3 was used, and thought that adding the redirect status code to `Retry.RETRY_AFTER_STATUS_CODES` would cause it to wait for Retry-After, then redirect. Instead this resulted in waiting for Retry-After, then **retrying the original request**, all in the inner loop, without popping up to let requests reconfigure the request for a redirect.

With this change, we patch into the requests redirect handling logic instead, forcing it to sleep if a Retry-After header is present, then follow the redirect as normal.

I've tested this on a dummy test server sending normal, error and 301 Retry-After responses, and can probably make a simple unit test for it, but open to other ideas.