### PR TITLE
Add support for downloading collections

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -691,6 +691,7 @@ class DSSClient(SwaggerClient):
                 if (obj['uuid'], obj['version']) in _ignore:
                     logger.info("Ignoring already-seen collection %s version %s",
                                 obj['uuid'], obj['version'])
+                    continue
                 _ignore.append((obj['uuid'], obj['version']))
                 r = self._serialize_col_to_manifest(uuid=obj['uuid'],
                                                     replica=replica,

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -722,8 +722,6 @@ class DSSClient(SwaggerClient):
             download the latest. The version is a timestamp of bundle creation
             in RFC3339
         :param str download_dir: The directory into which to download
-        :param int max_depth: The amount of "levels" of the collection to
-            tolerate before raising an error
 
         Download a bundle and save it to the local filesystem as a directory.
         """

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -688,9 +688,9 @@ class DSSClient(SwaggerClient):
                 logger.warning("Failed to download file %s version %s",
                                obj['uuid'], obj['version'])
             elif obj['type'] == 'collection':
-                # If we've already seen this collection, carry on silently
                 if (obj['uuid'], obj['version']) in _ignore:
-                    continue
+                    logger.info("Ignoring already-seen collection %s version %s",
+                                obj['uuid'], obj['version'])
                 _ignore.append((obj['uuid'], obj['version']))
                 r = self._serialize_col_to_manifest(uuid=obj['uuid'],
                                                     replica=replica,

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -555,6 +555,11 @@ class TestDownload(AbstractTestDSSClient):
         result in a :exc:`RuntimeError` (see
         :meth:`test_collection_download_nested`).
         """
+        # For what it's worth, I can't find a way to create this in the
+        # DSS, since I can't create a collection that contains another
+        # collection that doesn't yet exist. (And there is no way to
+        # update collections after creation.) That said, this purely
+        # hypothetical case is handled as it is specified in #339.
         test_col = self._generate_col_hierarchy(1)[0]
         test_col['contents'][0]['uuid'] = test_col['uuid']
         test_col['contents'][0]['version'] = test_col['version']

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -533,20 +533,6 @@ class TestDownload(AbstractTestDSSClient):
         skel['contents'][0]['uuid'] = child_uuid
         return [skel] + TestDownload._generate_col_hierarchy(depth - 1, child_uuid)
 
-    def test_collection_download_nested(self):
-        """
-        If a collection contains too many levels (>5), download
-        should fail.
-        """
-        test_cols = self._generate_col_hierarchy(10)
-        mock_get_col = self._fake_get_collection(test_cols)
-        with tempfile.TemporaryDirectory() as t:
-            with self.assertRaises(RuntimeError) as e:
-                with patch('hca.dss.DSSClient.get_collection', new=mock_get_col):
-                    self.dss.download_collection(uuid=test_cols[0]['uuid'],
-                                                 replica='aws', download_dir=t)
-        self.assertIn('Maximum depth', e.exception.args[0])
-
     def test_collection_download_self_nested(self):
         """
         If a collection contains itself, download should ignore

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -17,8 +17,7 @@ from hca.util.compat import USING_PYTHON2, walk
 from hca.dss import DSSClient
 
 if USING_PYTHON2:
-    import backports.tempfile
-    tempfile = backports.tempfile
+    import backports.tempfile as tempfile
 
 logging.basicConfig()
 


### PR DESCRIPTION
Preliminary support for `hca dss download-collection`.

Features:
* Takes advantage of parallelization in `DSSClient.download_manifest`
* Supports downloading nested collections and bundles
* Properly handles collections that contain themselves. (For what it's worth, I can't find a way to create this case in the DSS, since it prevents me from creating collections that contain collections that don't yet exist.)
* Will not download collections that contain bundles/collections that are nested too deeply (depth 4 by default, configurable)

Limitations:
* Files specified in a collection independent of a bundle cannot be downloaded. This is a limitation of `DSSClient.download_manifest`.

Closes #339 