### PR TITLE
[easy] Choose an unused port when logging in.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -414,7 +414,7 @@ class SwaggerClient(object):
                 from google_auth_oauthlib.flow import InstalledAppFlow
                 flow = InstalledAppFlow.from_client_config(self.application_secrets, scopes=scopes)
                 msg = "Authentication successful. Please close this tab and run HCA CLI commands in the terminal."
-                credentials = flow.run_local_server(success_message=msg, audience=self._audience, port=unused_tcp_port)
+                credentials = flow.run_local_server(success_message=msg, audience=self._audience, port=unused_tcp_port())
 
         # TODO: (akislyuk) test token autorefresh on expiration
         self.config.oauth2_token = dict(access_token=credentials.token,

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -130,7 +130,7 @@ class RetryPolicy(retry.Retry):
 def unused_tcp_port():
     with contextlib.closing(socket.socket()) as sock:
         sock.bind(('127.0.0.1', 0))
-    return sock.getsockname()[1]
+        return sock.getsockname()[1]
 
 
 class _ClientMethodFactory(object):


### PR DESCRIPTION
Should fix #352.

Using this blocks you as the port 8080 is hard-coded into the whitelist of accepted `callback_url`s.  A suggested work-around (with credit to @Bento007 ): https://community.auth0.com/t/allowed-callback-urls-ending-with-a-wildcard/7626/2

Currently could include changing `state` in the `query_params` to include a redirect to a whitelisted uri.