### PR TITLE
Skip download-collections tests on Windows

### DIFF
--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -165,6 +165,7 @@ class TestDssCLI(unittest.TestCase):
             # Deleting bundles is a privilege, not a right
             assert e.code == 403
 
+    @unittest.skipIf(os.name is 'nt', 'Unable to test on Windows')  # TODO windows testing refactor
     def test_collection_download(self):
         """
         Upload a bundle, add it to a collection, and try downloading

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -533,6 +533,7 @@ class TestDownload(AbstractTestDSSClient):
         skel['contents'][0]['uuid'] = child_uuid
         return [skel] + TestDownload._generate_col_hierarchy(depth - 1, child_uuid)
 
+    @unittest.skipIf(os.name is 'nt', 'Unable to test on Windows')  # TODO windows testing refactor
     def test_collection_download_self_nested(self):
         """
         If a collection contains itself, download should ignore
@@ -555,6 +556,7 @@ class TestDownload(AbstractTestDSSClient):
                 self.dss.download_collection(uuid=test_col['uuid'],
                                              replica='aws', download_dir=t)
 
+    @unittest.skipIf(os.name is 'nt', 'Unable to test on Windows')  # TODO windows testing refactor
     def test_collection_download_deep(self):
         """Test that we can download nested collections"""
         test_cols = self._generate_col_hierarchy(4)


### PR DESCRIPTION
`hca dss download-collections` relies on `hca.dss.download_manifest`, which [currently is not tested on Windows](https://github.com/HumanCellAtlas/dcp-cli/blob/7847a6a0c48d38777bda2740843cac23bfef2bd5/test/unit/test_dss_client.py#L187), causing Windows tests for #351 to fail. (I didn't catch that, sorry...)

This PR skips `download-collections` unit tests in the same way that `download_manifest` unit tests are skipped.