### PR TITLE
[easy] Help menu formatting.

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -19,7 +19,6 @@ import re
 import tempfile
 import time
 import uuid
-import shutil
 from io import open
 
 import requests
@@ -606,10 +605,6 @@ class DSSClient(SwaggerClient):
         return hasher.hexdigest()
 
     @classmethod
-    def _dir_path(cls, download_dir):
-        return os.path.join(download_dir, '.hca', 'v2')
-
-    @classmethod
     def _file_path(cls, checksum, download_dir):
         """
         returns a file's relative local path based on the nesting parameters and the files hash
@@ -619,7 +614,7 @@ class DSSClient(SwaggerClient):
         """
         checksum = checksum.lower()
         file_prefix = '_'.join(['files'] + list(map(str, cls.DIRECTORY_NAME_LENGTHS)))
-        path_pieces = [cls._dir_path(download_dir), file_prefix]
+        path_pieces = [download_dir, '.hca', 'v2', file_prefix]
         checksum_index = 0
         assert(sum(cls.DIRECTORY_NAME_LENGTHS) <= len(checksum))
         for prefix_length in cls.DIRECTORY_NAME_LENGTHS:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -107,7 +107,7 @@ from requests_oauthlib import OAuth2Session
 from urllib3.util import retry, timeout
 from jsonpointer import resolve_pointer
 from threading import Lock
-
+from argparse import RawTextHelpFormatter
 from dcplib.networking import Session
 
 from .. import get_config, logger
@@ -611,7 +611,8 @@ class SwaggerClient(object):
             subcommand_name = method_name.replace("_", "-")
             subparser = subparsers.add_parser(subcommand_name,
                                               help=method_data.get("summary"),
-                                              description=method_data.get("description"))
+                                              description=method_data.get("description"),
+                                              formatter_class=RawTextHelpFormatter)
             if help_menu:
                 required_group_parser = subparser.add_argument_group('Required Arguments')
             for param_name, param in method_data["signature"].parameters.items():
@@ -638,7 +639,8 @@ class SwaggerClient(object):
             method_args = _parse_docstring(docstring)
             command_subparser = subparsers.add_parser(command.__name__.replace("_", "-"),
                                                       help=method_args['summary'],
-                                                      description=method_args['description'])
+                                                      description=method_args['description'],
+                                                      formatter_class=RawTextHelpFormatter)
             if help_menu:
                 required_group_parser = command_subparser.add_argument_group('Required Arguments')
             for param_name, param_data in sig.parameters.items():


### PR DESCRIPTION
This passes in the raw text formatter to the subparsers, allowing docstrings to print things like newlines in the help menu.  I also added some periods in the docstring itself to better separate the text.