### PR TITLE
Batch Checkout for hca dss download [wip]

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -63,6 +63,7 @@ class DSSFile(namedtuple('DSSFile', ['name', 'uuid', 'version', 'sha256', 'size'
         return cls(name='bundle.json',
                    uuid=bundle_uuid,
                    version=datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ"),
+                   # TODO channge this to bundle_version from manifest
                    sha256=hashlib.sha256(metadata_bytes).hexdigest(),
                    size=len(metadata_bytes),
                    indexed=False,
@@ -443,6 +444,7 @@ class DSSClient(SwaggerClient):
             executor.submit(self._download_and_link_to_filestore, download_dir, dss_file, file_path,
                             num_retries=num_retries, min_delay_seconds=min_delay_seconds)
         #  TODO error handling here
+
     def _download_metadata(self, metadata, download_dir, bundle_dir, dss_file):
         dest_path = self._file_path(dss_file.sha256, download_dir)
         if os.path.exists(dest_path):

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -130,7 +130,7 @@ class _ClientMethodFactory(object):
         self.__dict__.update(locals())
         self._context_manager_response = None
 
-    def _request(self, req_args, retries, url=None, stream=False, headers=None):
+    def _request(self, req_args, url=None, stream=False, headers=None, retries=None):
         supplied_path_params = [p for p in req_args if p in self.path_parameters and req_args[p] is not None]
         if url is None:
             url = self.client.host + self.client.http_paths[self.method_name][frozenset(supplied_path_params)]
@@ -148,7 +148,9 @@ class _ClientMethodFactory(object):
         json_input = body if self.body_props else None
         headers = headers if headers else {}
         kwargs = {'json': json_input, 'params': query, 'stream': stream, 'headers': headers,
-                  'timeout': self.client.timeout_policy, 'retries': retries}
+                  'timeout': self.client.timeout_policy}
+        if retries:
+            kwargs['retries'] = retries
         res = session.request(self.http_method, url, **kwargs)
         if res.status_code >= 400:
             raise SwaggerAPIException(response=res)

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -130,40 +130,7 @@ class _ClientMethodFactory(object):
         self.__dict__.update(locals())
         self._context_manager_response = None
 
-    def request_with_retries_on_post_search(self, session, url, query, json_input, stream, headers):
-        """
-        Submit a request and retry POST search requests specifically.
-
-        We don't currently retry on POST requests, and this is intended as a temporary fix until
-        the swagger is updated and changes applied to prod.  In the meantime, this function will add
-        retries specifically for POST search (and any other POST requests will not be retried).
-        """
-        # TODO: Revert this PR as soon as the appropriate swagger definitions have percolated up
-        # to prod and merged; see https://github.com/HumanCellAtlas/data-store/pull/1961
-        status_code = 500
-        if '/v1/search' in url:
-            retry_count = 10
-        else:
-            retry_count = 1
-        while status_code in (500, 502, 503, 504) and retry_count > 0:
-            try:
-                retry_count -= 1
-                res = session.request(self.http_method,
-                                      url,
-                                      params=query,
-                                      json=json_input,
-                                      stream=stream,
-                                      headers=headers,
-                                      timeout=self.client.timeout_policy)
-                status_code = res.status_code
-            except SwaggerAPIException:
-                if retry_count > 0:
-                    pass
-                else:
-                    raise
-        return res
-
-    def _request(self, req_args, url=None, stream=False, headers=None):
+    def _request(self, req_args, retries, url=None, stream=False, headers=None):
         supplied_path_params = [p for p in req_args if p in self.path_parameters and req_args[p] is not None]
         if url is None:
             url = self.client.host + self.client.http_paths[self.method_name][frozenset(supplied_path_params)]
@@ -180,7 +147,9 @@ class _ClientMethodFactory(object):
         # TODO: (akislyuk) if using service account credentials, use manual refresh here
         json_input = body if self.body_props else None
         headers = headers if headers else {}
-        res = self.request_with_retries_on_post_search(session, url, query, json_input, stream, headers)
+        kwargs = {'json': json_input, 'params': query, 'stream': stream, 'headers': headers,
+                  'timeout': self.client.timeout_policy, 'retries': retries}
+        res = session.request(self.http_method, url, **kwargs)
         if res.status_code >= 400:
             raise SwaggerAPIException(response=res)
         return res

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -149,8 +149,8 @@ class _ClientMethodFactory(object):
         headers = headers if headers else {}
         kwargs = {'json': json_input, 'params': query, 'stream': stream, 'headers': headers,
                   'timeout': self.client.timeout_policy}
-        if retries:
-            kwargs['retries'] = retries
+        if retries is not None:
+            kwargs['allow_redirects'] = retries
         res = session.request(self.http_method, url, **kwargs)
         if res.status_code >= 400:
             raise SwaggerAPIException(response=res)


### PR DESCRIPTION
Threads attempt to initiate checkouts before downloading data.
Does not force thread to stay with file as it attempts to 'retry' and get into the checkout bucket. 
Queue file downloads by size of the file, smaller to larger.
