### PR TITLE
Fix bugs in bundle.json download

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -409,7 +409,7 @@ class DSSClient(SwaggerClient):
                                  bundle_dir,
                                  manifest_dss_file))
 
-        for file_ in manifest['bundle']['files'].values():
+        for file_ in manifest['bundle']['files']:
             dss_file = DSSFile.from_dss_bundle_response(file_, replica)
             filename = file_.get("name", dss_file.uuid)
             walking_dir = bundle_dir
@@ -449,7 +449,9 @@ class DSSClient(SwaggerClient):
         """
         pages = self.get_bundle.paginate(uuid=bundle_uuid, replica=replica, version=version if version else None)
         files = {}
+        ordered_files = []
         for page in pages:
+            ordered_files += page['bundle']['files']
             for file_ in page['bundle']['files']:
                 # The file name collision check is case-insensitive even if the local file system we're running on is
                 # case-sensitive. We do this in order to get consistent download behavior on all operating systems and
@@ -466,7 +468,7 @@ class DSSClient(SwaggerClient):
                 manifest = page
         # there will always be one page (or else we would have gotten a 404)
         # noinspection PyUnboundLocalVariable
-        manifest['bundle']['files'] = files
+        manifest['bundle']['files'] = ordered_files
         return manifest
 
     def _download_manifest_tasks(self, manifest, replica, num_retries, min_delay_seconds, download_dir):

--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -59,7 +59,11 @@ class DSSFile(namedtuple('DSSFile', ['name', 'uuid', 'version', 'sha256', 'size'
                    replica=replica)
 
     @classmethod
-    def from_bundle_json(cls, manifest_bytes, bundle_uuid, version, replica):
+    def for_bundle_manifest(cls, manifest_bytes, bundle_uuid, version, replica):
+        """
+        Even though the bundle manifest is not a DSS file, we need to wrap it's info in a DSSFile object for consistency
+        and logging purposes.
+        """
         return cls(name='bundle.json',
                    uuid=bundle_uuid,
                    version=version,
@@ -401,7 +405,7 @@ class DSSClient(SwaggerClient):
 
         # Download bundle.json (manifest for bundle as a file)
         manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
-        manifest_dss_file = DSSFile.from_bundle_json(manifest_bytes, bundle_uuid, bundle_version, replica)
+        manifest_dss_file = DSSFile.for_bundle_manifest(manifest_bytes, bundle_uuid, bundle_version, replica)
         yield (manifest_dss_file,
                functools.partial(self._download_bundle_manifest,
                                  manifest_bytes,

--- a/test/unit/test_dss_client.py
+++ b/test/unit/test_dss_client.py
@@ -414,12 +414,12 @@ class TestManifestDownloadBundle(AbstractTestDSSClient):
         self.assertEqual(dss_file.name, 'bundle.json')
         task()
         actual_files = self._files_present()
-        expected_hash = '5eea2e2bf59b04758dd8265d8acaaef4d382a9cc899a0a01f7ed42d7b0591b94'
+        expected_hash = '79a04be897c762008078631346bf39ea86af3d8fb653fec0e235f892ab9776b6'
         bundle_json_path = os.path.join('.', 'a_uuid.1_version', 'bundle.json')
         expected_files = {
             bundle_json_path,
             os.path.join('.', 'manifest.tsv'),
-            os.path.join('.', self.version_dir, '5e', 'ea2e', expected_hash)
+            os.path.join('.', self.version_dir, '79', 'a04b', expected_hash)
         }
         self.assertEqual(expected_files, actual_files)
         with open(bundle_json_path, 'rb') as f:
@@ -484,12 +484,12 @@ class TestDownload(AbstractTestDSSClient):
         self.assertEqual(dss_file.name, 'bundle.json')
         task()
         actual_files = self._files_present()
-        expected_hash = '5eea2e2bf59b04758dd8265d8acaaef4d382a9cc899a0a01f7ed42d7b0591b94'
+        expected_hash = '79a04be897c762008078631346bf39ea86af3d8fb653fec0e235f892ab9776b6'
         bundle_json_path = os.path.join('.', 'a_uuid.1_version', 'bundle.json')
         expected_files = {
             bundle_json_path,
             os.path.join('.', 'manifest.tsv'),
-            os.path.join('.', self.version_dir, '5e', 'ea2e', expected_hash)
+            os.path.join('.', self.version_dir, '79', 'a04b', expected_hash)
         }
         self.assertEqual(expected_files, actual_files)
         with open(bundle_json_path, 'rb') as f:


### PR DESCRIPTION
This PR fixes several things:
- Renames the internal variables to make it more clear that the `bundle.json` is the bundle manifest
- Fixes the bundle timestamp to be the bundle version
- Return the files in `bundle.json` as an array (instead of a dict like before)