### PR TITLE
Fix get collection iteration bug.

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -234,7 +234,7 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
                 for file in page.json()['bundle']['files']:
                     yield file
             else:
-                for collection in page.json().get('collections'):
+                for collection in page.json().get('collections', []):
                     yield collection
 
     def paginate(self, **kwargs):


### PR DESCRIPTION
Should fix this (when no collections exist):
```
from hca import HCAConfig
from hca.dss import DSSClient

hca_config = HCAConfig()
hca_config["DSSClient"].swagger_url = f"https://dss.data.humancellatlas.org/v1/swagger.json"
dss = DSSClient(config=hca_config)


def find_bundles(client, replica, project_uuid):
    q = {
        "query": {
            "bool": {
                "must": [
                    {
                        "match": {
                            "files.project_json.provenance.document_id": project_uuid
                        }
                    }
                ],
                "must_not": [
                    {
                        "match": {
                            "files.analysis_process_json.type.text": "analysis"
                        }
                    }
                ]
            }
        }
    }
    for hit in client.post_search.iterate(replica=replica, es_query=q, per_page=500):
        yield hit

for b in find_bundles(dss, 'aws', '2cd14cf5-f8e0-4c97-91a2-9e8957f41ea8'):
    print(b)

```
Bug:
```
Traceback (most recent call last):
  File "./find_bundles_for_project.py", line 45, in <module>
    for hit in find_bundles(client, args.replica, args.project_uuid):
  File "./find_bundles_for_project.py", line 35, in find_bundles
    for hit in client.post_search.iterate(replica=replica, es_query=q, per_page=500):
  File "/home/dcp/.virtualenvs/dcp/lib/python3.6/site-packages/hca/util/__init__.py", line 237, in iterate
    for collection in page.json().get('collections'):
TypeError: 'NoneType' object is not iterable
```