### PR TITLE
Show errors with `hca dss upload -q`

### DIFF
--- a/hca/upload/cli/upload_command.py
+++ b/hca/upload/cli/upload_command.py
@@ -5,8 +5,6 @@ import boto3
 
 from hca.upload import UploadService
 from .common import UploadCLICommand
-from ..upload_area import UploadArea
-from ..upload_config import UploadConfig
 
 
 class UploadCommand(UploadCLICommand):

--- a/hca/upload/lib/s3_agent.py
+++ b/hca/upload/lib/s3_agent.py
@@ -131,11 +131,10 @@ class S3Agent:
         """ Returns true if the key already exists in the current bucket and the clientside checksum matches the
         file's checksums, and false otherwise."""
         try:
-            obj = self.target_s3.meta.client.head_object(Bucket=bucket, Key=key)
-            if obj and 'Metadata' in obj:
-                if obj['Metadata'] == checksums:
-                    return True
+            obj = self.target_s3.meta.client.head_object(Bucket=bucket, Key=key) or {}
         except ClientError:
             # An exception from calling `head_object` indicates that no file with the specified name could be found
             # in the specified bucket.
             return False
+        if obj.get('Metadata') == checksums:
+            return True

--- a/hca/upload/lib/s3_agent.py
+++ b/hca/upload/lib/s3_agent.py
@@ -132,7 +132,7 @@ class S3Agent:
         file's checksums, and false otherwise."""
         try:
             obj = self.target_s3.meta.client.head_object(Bucket=bucket, Key=key)
-            if obj and obj.containsKey('Metadata'):
+            if obj and 'Metadata' in obj:
                 if obj['Metadata'] == checksums:
                     return True
         except ClientError:

--- a/hca/upload/upload_area.py
+++ b/hca/upload/upload_area.py
@@ -124,18 +124,17 @@ class UploadArea:
                           report_progress=report_progress,
                           sync=sync)
         pool.wait_for_completion()
-        if report_progress:
-            number_of_errors = len(self.s3agent.failed_uploads)
-            if number_of_errors == 0:
-                print(
-                    "Completed upload of %d files to upload area %s\n" %
-                    (self.s3agent.file_upload_completed_count, self.uuid))
-            else:
-                error = "\nThe following files failed:"
-                for k, v in self.s3agent.failed_uploads.items():
-                    error += "\n%s: [Exception] %s" % (k, v)
-                error += "\nPlease retry or contact an hca administrator at data-help@humancellatlas.org for help.\n"
-                raise UploadException(error)
+        number_of_errors = len(self.s3agent.failed_uploads)
+        if report_progress and number_of_errors == 0:
+            print(
+                "Completed upload of %d files to upload area %s\n" %
+                (self.s3agent.file_upload_completed_count, self.uuid))
+        elif number_of_errors > 0:
+            error = "\nThe following files failed:"
+            for k, v in self.s3agent.failed_uploads.items():
+                error += "\n%s: [Exception] %s" % (k, v)
+            error += "\nPlease retry or contact an hca administrator at data-help@humancellatlas.org for help.\n"
+            raise UploadException(error)
 
     def validate_files(self, file_list, validator_image, original_validation_id="", environment={}):
         """

--- a/test/integration/upload/__init__.py
+++ b/test/integration/upload/__init__.py
@@ -39,6 +39,11 @@ class UploadTestCase(unittest.TestCase):
         self.sts_mock.stop()
         self.tweak_resetter.restore_config()
 
+    @staticmethod
+    def add_upload_mock(uuid, path):
+        url = 'https://upload.test.data.humancellatlas.org/v1/area/{uuid}/{path}'
+        responses.add(responses.POST, url.format(path=path, uuid=uuid), status=200)
+
     def mock_current_upload_area(self, area_uuid=None, bucket_name=None):
         area = self.mock_upload_area(area_uuid=area_uuid, bucket_name=bucket_name)
         UploadConfig().select_area(area.uuid)
@@ -87,4 +92,3 @@ class UploadTestCase(unittest.TestCase):
     def _make_area_uri(self, area_uuid=None):
         return "s3://{bucket}/{uuid}/".format(bucket=self.upload_bucket_name,
                                               uuid=(area_uuid or str(uuid.uuid4())))
-

--- a/test/integration/upload/cli/test_upload.py
+++ b/test/integration/upload/cli/test_upload.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import itertools
 import os
 import sys
 import unittest
@@ -24,6 +24,19 @@ class TestUploadCliUploadCommand(UploadTestCase):
         self.area = self.mock_current_upload_area()
         self.test_files = ['LICENSE', 'README.rst']
 
+    def upload_command(self, args):
+        paths = []
+        if args.target_filename:
+            paths.append(args.target_filename)
+        for arg in args.upload_paths:
+            if os.path.isdir(arg):
+                paths.extend(itertools.chain.from_iterable((f for _, _, f in os.walk(arg))))
+            else:
+                paths.append(arg)
+        for path in paths:
+            self.add_upload_mock(self.area.uuid, path)
+        return UploadCommand(args)
+
     @responses.activate
     def test_upload_with_target_filename_option(self):
         args = Namespace(
@@ -36,7 +49,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-        UploadCommand(args)
+        self.upload_command(args)
 
         obj = self.upload_bucket.Object("{}/FOO".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/json; dcp-type=data')
@@ -49,7 +62,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         s3_path_with_no_prefix = "s3://fake-bucket"
 
         bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
@@ -62,7 +75,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         s3_path_with_no_prefix = "s3://fake-bucket/fake-dir/"
 
         bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
@@ -75,7 +88,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         s3_path_with_no_prefix = "s3://fake-bucket/fake-dir/fake-obj"
 
         bucket, prefix = upload_command._parse_s3_path(s3_path_with_no_prefix)
@@ -88,7 +101,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         area_s3_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
 
         s3_file_paths, total_fize_size = upload_command._retrieve_files_list_and_size_sum_tuple_from_s3_path(
@@ -104,7 +117,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
         partial_obj_key = "{0}/LIC".format(area_path)
         complete_obj_key = "{0}/LICENSE".format(area_path)
@@ -121,7 +134,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
         partial_obj_key = "{0}/LIC".format(area_path)
         complete_obj_key = "{0}/LICENSE".format(area_path)
@@ -137,7 +150,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
         args = Namespace(upload_paths=self.test_files, target_filename=None, no_transfer_acceleration=False,
                          dcp_type=None, quiet=True, file_extension=None, sync=True)
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        upload_command = UploadCommand(args)
+        upload_command = self.upload_command(args)
         area_path = "s3://{0}/{1}".format(self.upload_bucket_name, self.area.uuid)
         complete_obj_key = "{0}/LICENSE".format(area_path)
 
@@ -155,7 +168,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-        UploadCommand(args)
+        self.upload_command(args)
 
         obj = self.upload_bucket.Object("{}/LICENSE".format(self.area.uuid))
         self.assertEqual(obj.content_type, 'application/octet-stream; dcp-type=data')
@@ -174,12 +187,12 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
             self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-            UploadCommand(args)
+            self.upload_command(args)
             mock_config.assert_called_once_with(s3={'use_accelerate_endpoint': True})
 
             mock_config.reset_mock()
             args.no_transfer_acceleration = True
-            UploadCommand(args)
+            self.upload_command(args)
             mock_config.assert_called_once_with()
 
     @responses.activate
@@ -189,7 +202,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-        UploadCommand(args)
+        self.upload_command(args)
 
         for filename in self.test_files:
             obj = self.upload_bucket.Object("{}/{}".format(self.area.uuid, filename))
@@ -204,10 +217,10 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-        UploadCommand(args)
+        self.upload_command(args)
         last_modified_time_for_first_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
-        UploadCommand(args)
+        self.upload_command(args)
         last_modified_time_for_second_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
 
@@ -220,10 +233,10 @@ class TestUploadCliUploadCommand(UploadTestCase):
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
-        UploadCommand(args)
+        self.upload_command(args)
         last_modified_time_for_first_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
-        UploadCommand(args)
+        self.upload_command(args)
         last_modified_time_for_second_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
 
@@ -241,7 +254,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
             sync=True)
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        UploadCommand(args)
+        self.upload_command(args)
         self.assertEqual(len(list(self.upload_bucket.objects.all())), 6)
 
     @responses.activate
@@ -256,7 +269,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
             sync=True)
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        UploadCommand(args)
+        self.upload_command(args)
         self.assertEqual(len(list(self.upload_bucket.objects.all())), 3)
 
     @responses.activate
@@ -272,7 +285,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
             sync=True)
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        UploadCommand(args)
+        self.upload_command(args)
         self.assertEqual(len(list(self.upload_bucket.objects.all())), 3)
 
     @responses.activate
@@ -288,7 +301,7 @@ class TestUploadCliUploadCommand(UploadTestCase):
             sync=True)
 
         self.simulate_credentials_api(area_uuid=self.area.uuid)
-        UploadCommand(args)
+        self.upload_command(args)
         self.assertEqual(len(list(self.upload_bucket.objects.all())), 2)
 
 

--- a/test/integration/upload/cli/test_upload.py
+++ b/test/integration/upload/cli/test_upload.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 import itertools
+import time
 import os
 import sys
 import unittest
@@ -220,11 +221,12 @@ class TestUploadCliUploadCommand(UploadTestCase):
         self.upload_command(args)
         last_modified_time_for_first_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
+        time.sleep(5)
         self.upload_command(args)
         last_modified_time_for_second_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
 
-        self.assertTrue(last_modified_time_for_first_attempted_upload == last_modified_time_for_second_attempted_upload)
+        self.assertEqual(last_modified_time_for_first_attempted_upload, last_modified_time_for_second_attempted_upload)
 
     @responses.activate
     def test_upload_overwrite_same_file_with_sync_off(self):
@@ -236,11 +238,12 @@ class TestUploadCliUploadCommand(UploadTestCase):
         self.upload_command(args)
         last_modified_time_for_first_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
+        time.sleep(5)  # sit in the corner and think about what you've done
         self.upload_command(args)
         last_modified_time_for_second_attempted_upload = self.upload_bucket.Object(
             "{}/LICENSE".format(self.area.uuid)).last_modified
 
-        self.assertTrue(last_modified_time_for_first_attempted_upload < last_modified_time_for_second_attempted_upload)
+        self.assertLess(last_modified_time_for_first_attempted_upload, last_modified_time_for_second_attempted_upload)
 
     @responses.activate
     def test_directory_upload_path_without_file_extension(self):

--- a/test/integration/upload/cli/test_upload.py
+++ b/test/integration/upload/cli/test_upload.py
@@ -26,16 +26,12 @@ class TestUploadCliUploadCommand(UploadTestCase):
         self.test_files = ['LICENSE', 'README.rst']
 
     def upload_command(self, args):
-        paths = []
-        if args.target_filename:
-            paths.append(args.target_filename)
-        for arg in args.upload_paths:
+        for arg in args.upload_paths + [args.target_filename or '']:
             if os.path.isdir(arg):
-                paths.extend(itertools.chain.from_iterable((f for _, _, f in os.walk(arg))))
-            else:
-                paths.append(arg)
-        for path in paths:
-            self.add_upload_mock(self.area.uuid, path)
+                for path in itertools.chain.from_iterable((f for _, _, f in os.walk(arg))):
+                    self.add_upload_mock(self.area.uuid, path)
+            elif arg:  # ignore '' (but not arbitrary file names)
+                self.add_upload_mock(self.area.uuid, arg)
         return UploadCommand(args)
 
     @responses.activate

--- a/test/integration/upload/test_upload_area.py
+++ b/test/integration/upload/test_upload_area.py
@@ -178,6 +178,7 @@ class TestUploadAreaFileUpload(UploadTestCase):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
 
         file_path = os.path.join(TEST_DIR, "res", "bundle", "assay.json")
+        self.add_upload_mock(self.area.uuid, 'assay.json')
         self.area.upload_files(file_paths=[file_path])
 
         obj = self.upload_bucket.Object("{}/assay.json".format(self.area.uuid))
@@ -189,6 +190,7 @@ class TestUploadAreaFileUpload(UploadTestCase):
     @responses.activate
     def test_file_upload_with_target_filename_option(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
+        self.add_upload_mock(self.area.uuid, 'POO')
 
         self.area.upload_files(file_paths=["LICENSE"], target_filename='POO')
 
@@ -224,6 +226,7 @@ class TestUploadAreaFileUpload(UploadTestCase):
     def test_test_s3_agent_setup_for_file_upload__for_single_file__computes_stats_correctly(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
         file_paths = ["LICENSE"]
+        self.add_upload_mock(self.area.uuid, 'LICENSE')
 
         self.area.upload_files(file_paths=file_paths, file_size_sum=1078)
 
@@ -235,6 +238,7 @@ class TestUploadAreaFileUpload(UploadTestCase):
     def test_test_s3_agent_setup_for_file_upload__for_multiple_files__computes_stats_correctly(self):
         self.simulate_credentials_api(area_uuid=self.area.uuid)
         file_paths = ["LICENSE", "LICENSE"]
+        self.add_upload_mock(self.area.uuid, 'LICENSE')
 
         self.area.upload_files(file_paths=file_paths, file_size_sum=2156)
 


### PR DESCRIPTION
Closes #188.

This PR changes the behavior of `hca dss upload -q` to show error messages where they were previously suppressed. This fix revealed an apparent misconfiguration in test.integration.upload.cli.test_upload that caused some failing tests to be erroneously reported as passing.