### PR TITLE
Adding header values into request when values are present in req_args

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -138,7 +138,7 @@ class _ClientMethodFactory(object):
 
         # TODO: (akislyuk) if using service account credentials, use manual refresh here
         json_input = body if self.body_props else None
-        headers = headers if headers else {}
+        headers = headers or {}
         headers.update({k: v for k, v in req_args.items() if self.parameters.get(k, {}).get('in') == 'header'})
         res = session.request(self.http_method, url, params=query, json=json_input, stream=stream,
                               headers=headers, timeout=self.client.timeout_policy)

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -139,6 +139,7 @@ class _ClientMethodFactory(object):
         # TODO: (akislyuk) if using service account credentials, use manual refresh here
         json_input = body if self.body_props else None
         headers = headers if headers else {}
+        headers.update({k: v for k, v in req_args.items() if self.parameters.get(k, {}).get('in') == 'header'})
         res = session.request(self.http_method, url, params=query, json=json_input, stream=stream,
                               headers=headers, timeout=self.client.timeout_policy)
         if res.status_code >= 400:


### PR DESCRIPTION
Given an OpenAPI specification:
```
...
path:
  /foo:
    get:
      parameters:
        - in: header
          name: bar
          schema:
            type: string
          required: true
...
```
`SwaggerClient.foo(bar="abcd")`, a functions generated after parsing this specification will not apply `bar="abcd" to the header of the request. The following PR fixes this.
