### PR TITLE
Misc fixes

### DIFF
--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -494,14 +494,15 @@ class SwaggerClient(object):
         return body_props, method_args
 
     def _build_client_method(self, http_method, http_path, method_data):
-        method_name_parts = [http_method] + [p for p in http_path.split("/")[1:] if not p.startswith("{")]
+        _http_path = http_path.replace('.', '').replace('-', '_')
+        method_name_parts = [http_method] + [p for p in _http_path.split("/")[1:] if not p.startswith("{")]
         method_name = "_".join(method_name_parts)
-        if method_name.endswith("s") and (http_method.upper() in {"POST", "PUT"} or http_path.endswith("/{uuid}")):
+        if method_name.endswith("s") and (http_method.upper() in {"POST", "PUT"} or _http_path.endswith("/{uuid}")):
             method_name = method_name[:-1]
 
         parameters = {p["name"]: p for p in method_data.get("parameters", [])}
         body_json_schema = {"properties": {}}
-        if "requestBody" in method_data:
+        if "requestBody" in method_data and "application/json" in method_data["requestBody"]["content"]:
             body_json_schema = method_data["requestBody"]["content"]["application/json"]["schema"]
         else:
             for p in parameters:

--- a/test/res/test_swagger.json
+++ b/test/res/test_swagger.json
@@ -281,6 +281,87 @@
           }
         }
       }
+    },
+    "/with/special_characters.-/in/path": {
+      "get": {
+        "description": "GET method with special characters.",
+        "summary": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/with/header/parameter": {
+      "get": {
+        "description": "GET a method a header parameter.",
+        "summary": "",
+        "parameters": [
+          {
+            "name": "some_header",
+            "description": "A required header parameter.",
+            "in": "header",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/with/request_body/application/json": {
+      "get": {
+        "description": "GET a method a header parameter.",
+        "summary": "",
+        "requestBody":{
+          "content": {
+            "application/json":{
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/with/request_body/not_application/json": {
+      "get": {
+        "description": "GET a method a header parameter.",
+        "summary": "",
+        "requestBody":{
+          "content": {
+            "application/json":{
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Check for content type application/json before trying to parse.
- Storying the modified `http_path` in `_http_path` to avoid corruption of path url when making requests. This happens in the case where a valid path: `/.well-known/openid-configuration` is replace with the invalid path: `/well_known/openid_configuration` during the request.