### PR TITLE
Fix documentation - remove extra periods between paragraphs

### DIFF
--- a/hca/dss/__init__.py
+++ b/hca/dss/__init__.py
@@ -279,28 +279,28 @@ class DSSClient(SwaggerClient):
         Files are always downloaded to a cache / filestore directory called '.hca'. This directory is created in the
         current directory where download is initiated. A copy of the manifest used is also written to the current
         directory. This manifest has an added column that lists the paths of the files within the '.hca' filestore.
-        .
+
         The default layout is **none**. In this layout all of the files are downloaded to the filestore and the
         recommended way of accessing the files in by parsing the manifest copy that's written to the download
         directory.
-        .
+
         The bundle layout still downloads all of files to the filestore. For each bundle mentioned in the
         manifest a directory is created. All relevant metadata files for each bundle are linked into these
         directories in addition to relevant data files mentioned in the manifest.
-        .
+
         Each row in the manifest represents one file in DSS. The manifest must have a header row. The header row
-        must declare the following columns.
-        .
-        `bundle_uuid` - the UUID of the bundle containing the file in DSS.
-        `bundle_version` - the version of the bundle containing the file in DSS.
-        `file_name` - the name of the file as specified in the bundle.
-        `file_uuid` - the UUID of the file in the DSS.
-        `file_sha256` - the SHA-256 hash of the file.
-        `file_size` - the size of the file.
-        .
+        must declare the following columns:
+
+        - `bundle_uuid` - the UUID of the bundle containing the file in DSS.
+        - `bundle_version` - the version of the bundle containing the file in DSS.
+        - `file_name` - the name of the file as specified in the bundle.
+        - `file_uuid` - the UUID of the file in the DSS.
+        - `file_sha256` - the SHA-256 hash of the file.
+        - `file_size` - the size of the file.
+
         The TSV may have additional columns. Those columns will be ignored. The ordering of the columns is
         insignificant because the TSV is required to have a header row.
-        .
+
         This download format will serve as the main storage format for downloaded files. If a user specifies a different
         format for download (coming in the future) the files will first be downloaded in this format, then hard-linked
         to the user's preferred format.

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -49,6 +49,17 @@ def _md2rst(docstring):
     return renderer.render(ast)
 
 
+def _render_bullet_list(node):
+    """Render a docstrings bullet list as plain text"""
+    # Extract and use the bullet character in the list
+    bc = [j[1] for j in node.attlist() if j[0] == 'bullet'][0]
+    result = "\n\n"
+    for child in node.children:
+        result += f"{bc} {child.astext()}\n"
+    result += "\n"
+    return result
+
+
 def _parse_docstring(docstring):
     """
     Using the sphinx RSTParse to parse __doc__ for argparse `parameters`, `help`, and `description`. The first
@@ -94,6 +105,8 @@ def _parse_docstring(docstring):
             method_args['summary'] = node.astext()
         elif node.tagname == 'field_list':
             get_params(node, method_args['params'])
+        elif node.tagname is 'bullet_list':
+            method_args['description'] += _render_bullet_list(node)
         else:
-            method_args['description'] += '\n' + node.astext()
+            method_args['description'] += '\n\n' + node.astext()
     return method_args

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -52,7 +52,7 @@ def _md2rst(docstring):
 def _parse_docstring(docstring):
     """
     Using the sphinx RSTParse to parse __doc__ for argparse `parameters`, `help`, and `description`. The first
-    rst paragraph encountered it treated as the argparse help text. Any param fields are treated as argparse
+    rst paragraph encountered is treated as the argparse help text. Any param fields are treated as argparse
     arguments. Any other text is combined and added to the argparse description.
 
     example:

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -55,7 +55,7 @@ def _render_bullet_list(node):
     bc = [j[1] for j in node.attlist() if j[0] == 'bullet'][0]
     result = "\n\n"
     for child in node.children:
-        result += f"{bc} {child.astext()}\n"
+        result += "%s %s\n" % (bc, child.astext())
     result += "\n"
     return result
 

--- a/hca/util/_docs.py
+++ b/hca/util/_docs.py
@@ -105,7 +105,7 @@ def _parse_docstring(docstring):
             method_args['summary'] = node.astext()
         elif node.tagname == 'field_list':
             get_params(node, method_args['params'])
-        elif node.tagname is 'bullet_list':
+        elif node.tagname == 'bullet_list':
             method_args['description'] += _render_bullet_list(node)
         else:
             method_args['description'] += '\n\n' + node.astext()


### PR DESCRIPTION
This will address one of the items brought up in issue #443 

The documentation has [a paragraph](https://hca.readthedocs.io/en/latest/cli.html#download-manifest) with stray commas everywhere, this fixes the problem