### PR TITLE
Unpin cryptography dependency and set min version to 2.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ awscli>1.15.70
 boto3 > 1.8
 botocore>=1.12.13
 commonmark >= 0.9.0, < 1
-cryptography==2.3.1
+cryptography >= 2.6.1, < 3
 dcplib >= 2.0.2, < 3
 docutils==0.14
 google-auth >= 1.0.2, < 2


### PR DESCRIPTION
This is required to run the HCA CLI on MacOS Catalina.