### PR TITLE
auto pagination

### DIFF
--- a/hca/cli.py
+++ b/hca/cli.py
@@ -144,7 +144,7 @@ def main(args=None):
             try:
                 err_log_filename = os.path.join(get_config().user_config_dir, "error.log")
                 with open(err_log_filename, "ab") as fh:
-                    print(datetime.datetime.now().isoformat(), file=fh)
+                    print(datetime.datetime.now().isoformat(), file=fh)  # noqa
                     print(err_msg, file=fh)
                 exit("{}: {}. See {} for error details.".format(e.__class__.__name__, e, err_log_filename))
             except Exception:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -92,6 +92,7 @@ import argparse
 import time
 import jwt
 import requests
+import jmespath
 
 from inspect import signature, Parameter
 from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
@@ -209,8 +210,13 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
             if response_data is None:
                 response_data = page
             else:
+
                 content_key = response_data['_internal_api_content_key']
-                response_data[content_key] += page[content_key]
+                data_aggregrator = jmespath.search(content_key, response_data)
+                patch = jmespath.search(content_key, page)
+                if patch:
+                    data_aggregrator += patch
+                response_data[content_key] = data_aggregrator
         response_data.pop('_internal_api_content_key')
         return response_data
 

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -542,10 +542,10 @@ class SwaggerClient(object):
         path_parameters = [p_name for p_name, p_data in parameters.items() if p_data["in"] == "path"]
         self.http_paths[method_name][frozenset(path_parameters)] = http_path
 
+        body_props, method_args = self._process_method_args(parameters=parameters, body_json_schema=body_json_schema)
+
         method_supports_pagination = True if str(requests.codes.partial) in method_data["responses"] else False
         highlight_streaming_support = True if str(requests.codes.found) in method_data["responses"] else False
-
-        body_props, method_args = self._process_method_args(parameters=parameters, body_json_schema=body_json_schema)
 
         factory = _PaginatingClientMethodFactory if method_supports_pagination else _ClientMethodFactory
         client_method = factory(self, parameters, path_parameters, http_method, method_name, method_data, body_props)

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -206,10 +206,6 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
             return super()._cli_call(cli_args)
         return self._auto_page(**vars(cli_args))
 
-    def __call__(self, client, **kwargs):
-        # auto pagination should not be available for python bindings, use paginate attribute instead.
-        return super().__call__(client, **kwargs)
-
     def _auto_page(self, **kwargs):
         '''This method allows for autopaging in commands and bindings'''
         response_data = None

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -199,7 +199,7 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
     def paginate(self, **kwargs):
         """Yield paginated responses one response body at a time."""
         for page in self._get_raw_pages(**kwargs):
-            yield page
+            yield page.json()
 
     def _cli_call(self, cli_args):
         if cli_args.paginate is not True:

--- a/hca/util/__init__.py
+++ b/hca/util/__init__.py
@@ -206,7 +206,6 @@ class _PaginatingClientMethodFactory(_ClientMethodFactory):
 
     def _cli_call(self, cli_args):
         if str.lower(vars(cli_args)['page']) == 'false':
-            print('super hit')
             return super()._cli_call(cli_args)
         else:
             response_data = None

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -27,7 +27,8 @@ class TestDssCLI(unittest.TestCase):
     def test_post_search_cli(self):
         query = json.dumps({})
         replica = "aws"
-        args = ["dss", "post-search", "--es-query", query, "--replica", replica, "--output-format", "raw"]
+        args = ["dss", "post-search", "--es-query", query, "--replica", replica,
+                "--output-format", "raw", "--no-paginate"]
         with CapturingIO('stdout') as stdout:
             hca.cli.main(args)
         result = json.loads(stdout.captured())

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -2,12 +2,16 @@
 # coding: utf-8
 import contextlib
 import filecmp
+import io
 import json
 import os
 import sys
 import unittest
+import unittest.mock
 import uuid
 import tempfile
+import requests
+from requests.models import Response
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -245,6 +249,39 @@ class TestDssCLI(unittest.TestCase):
                 self.assertFalse(diff.left_only)
                 self.assertFalse(diff.funny_files)
                 self.assertFalse(diff.diff_files)
+
+
+class SessionMock:
+    def __init__(self):
+        self.pages = [{"results": [f"result {i}"] * i} for i in range(3)]
+
+    def request(self, *args, **kwargs):
+        res = Response()
+        res.status_code = requests.codes.ok
+        page = self.pages.pop()
+        res.headers = {"link": '<https:///>; rel="next"'} if self.pages else {}
+        res.headers['content-type'] = 'application/json'
+        res.raw = io.BytesIO(json.dumps(page).encode())
+        return res
+
+
+class MockTestCase(unittest.TestCase):
+    def _test_with_mock(self, expected_length, no_pagination=False):
+        paged_args = ['dss', 'get-bundles-all', '--replica', 'aws']
+        if no_pagination is True:
+            paged_args.append('--no-paginate')
+        with CapturingIO('stdout') as stdout:
+            hca.cli.main(args=paged_args)
+        output = json.loads(stdout.captured())
+        self.assertEqual(expected_length,len(output['results']))
+
+    @unittest.mock.patch("hca.util.SwaggerClient._session", SessionMock())
+    def test_no_page(self):
+        self._test_with_mock(2, no_pagination=True)
+
+    @unittest.mock.patch("hca.util.SwaggerClient._session", SessionMock())
+    def test_page(self):
+        self._test_with_mock(3, no_pagination=False)
 
 
 if __name__ == "__main__":

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -254,7 +254,7 @@ class TestDssCLI(unittest.TestCase):
 
 class SessionMock:
     def __init__(self):
-        self.pages = [{"results": [f"result {i}"] * i} for i in range(3)]
+        self.pages = [{"results": ["result"] * i} for i in range(3)]
 
     def request(self, *args, **kwargs):
         res = Response()

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -265,6 +265,9 @@ class SessionMock:
         res.raw = io.BytesIO(json.dumps(page).encode())
         return res
 
+    def get(self, *args, **kwargs):
+        kwargs["method"] = "GET"
+        return self.request(*args, **kwargs)
 
 class MockTestCase(unittest.TestCase):
     def _test_with_mock(self, expected_length, no_pagination=False):


### PR DESCRIPTION
Allows for auto pagination for hca commands, turns on this feature by default.
Adds support for optional `--no-paginate` to fall back to single page response. 
Closes #461