### PR TITLE
Fix sub-command description indentation in sphinx docs

### DIFF
--- a/hca/cli.py
+++ b/hca/cli.py
@@ -90,6 +90,7 @@ def get_parser(help_menu=False):
     parser.add_parser_func(clear_hca_cache, help=clear_hca_cache.__doc__)
 
     def help(args):
+        """Print help message"""
         parser.print_help()
 
     parser.add_parser_func(help)

--- a/hca/upload/cli/creds_command.py
+++ b/hca/upload/cli/creds_command.py
@@ -3,8 +3,7 @@ from .common import UploadCLICommand
 
 
 class CredsCommand(UploadCLICommand):
-    """
-    Get/show AWS credentials for access to Upload Area
+    """Get/show AWS credentials for access to Upload Area
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/creds_command.py
+++ b/hca/upload/cli/creds_command.py
@@ -3,7 +3,7 @@ from .common import UploadCLICommand
 
 
 class CredsCommand(UploadCLICommand):
-    """Get/show AWS credentials for access to upload area
+    """Get/show AWS credentials for access to upload area.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/creds_command.py
+++ b/hca/upload/cli/creds_command.py
@@ -3,7 +3,7 @@ from .common import UploadCLICommand
 
 
 class CredsCommand(UploadCLICommand):
-    """Get/show AWS credentials for access to Upload Area
+    """Get/show AWS credentials for access to upload area
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/forget_command.py
+++ b/hca/upload/cli/forget_command.py
@@ -3,8 +3,7 @@ from .common import UploadCLICommand
 
 
 class ForgetCommand(UploadCLICommand):
-    """
-    Forget about upload area.
+    """Forget about upload area.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/generate_status_report_command.py
+++ b/hca/upload/cli/generate_status_report_command.py
@@ -6,7 +6,7 @@ from hca.upload.cli.common import UploadCLICommand
 
 
 class GenerateStatusReportCommand(UploadCLICommand):
-    """Generate file status report for upload area
+    """Generate file status report for upload area.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/generate_status_report_command.py
+++ b/hca/upload/cli/generate_status_report_command.py
@@ -6,8 +6,7 @@ from hca.upload.cli.common import UploadCLICommand
 
 
 class GenerateStatusReportCommand(UploadCLICommand):
-    """
-    Generate file status report for upload area
+    """Generate file status report for upload area
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/list_area_command.py
+++ b/hca/upload/cli/list_area_command.py
@@ -3,8 +3,7 @@ from .common import UploadCLICommand
 
 
 class ListAreaCommand(UploadCLICommand):
-    """
-    List contents of currently selected upload area.
+    """List contents of currently selected upload area.
     """
     @classmethod
     def add_parser(cls, staging_subparsers):

--- a/hca/upload/cli/list_areas_command.py
+++ b/hca/upload/cli/list_areas_command.py
@@ -5,8 +5,7 @@ from .common import UploadCLICommand
 
 
 class ListAreasCommand(UploadCLICommand):
-    """
-    List upload areas the current user has access to. Also see :py:class:`UploadArea`
+    """List upload areas the current user has access to. Also see :py:class:`UploadArea`
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/list_areas_command.py
+++ b/hca/upload/cli/list_areas_command.py
@@ -6,7 +6,7 @@ from .common import UploadCLICommand
 
 class ListAreasCommand(UploadCLICommand):
     """
-    List upload areas I know about.
+    List upload areas the current user has access to. Also see :py:class:`UploadArea`
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/list_areas_command.py
+++ b/hca/upload/cli/list_areas_command.py
@@ -5,7 +5,7 @@ from .common import UploadCLICommand
 
 
 class ListAreasCommand(UploadCLICommand):
-    """List upload areas the current user has access to. Also see :py:class:`UploadArea`
+    """List upload areas the current user has access to. Also see :py:class:`UploadArea`.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/list_file_status_command.py
+++ b/hca/upload/cli/list_file_status_command.py
@@ -7,8 +7,7 @@ from hca.upload.lib.upload_submission_state import FileStatusCheck
 
 
 class ListFileStatusCommand(UploadCLICommand):
-    """
-    Print status of file in an upload area
+    """Print status of file in an upload area
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/list_file_status_command.py
+++ b/hca/upload/cli/list_file_status_command.py
@@ -7,7 +7,7 @@ from hca.upload.lib.upload_submission_state import FileStatusCheck
 
 
 class ListFileStatusCommand(UploadCLICommand):
-    """Print status of file in an upload area
+    """Print status of file in an upload area.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/select_command.py
+++ b/hca/upload/cli/select_command.py
@@ -3,8 +3,7 @@ from .common import UploadCLICommand
 
 
 class SelectCommand(UploadCLICommand):
-    """
-    Select upload area to which you wish to upload files.
+    """Select upload area to which you wish to upload files.
     """
     @classmethod
     def add_parser(cls, upload_subparsers):

--- a/hca/upload/cli/upload_command.py
+++ b/hca/upload/cli/upload_command.py
@@ -8,8 +8,7 @@ from .common import UploadCLICommand
 
 
 class UploadCommand(UploadCLICommand):
-    """
-    Upload a file to the currently selected upload area.
+    """Upload a file to the currently selected upload area.
     """
     COMPARISON_TOOL = "https://s3-accelerate-speedtest.s3-accelerate.amazonaws.com/en/accelerate-speed-comparsion.html"
 


### PR DESCRIPTION
This PR fixes a problem with the sphinx docs that causes cli sub-command descriptions to be indented and be formatted as code blocks instead of normal text. Fixes an item in #443.