### PR TITLE
Change flags starting with - to start with --

### DIFF
--- a/hca/upload/cli/generate_status_report_command.py
+++ b/hca/upload/cli/generate_status_report_command.py
@@ -14,15 +14,15 @@ class GenerateStatusReportCommand(UploadCLICommand):
         gen_file_status_report_parser = upload_subparsers.add_parser('report', help=cls.__doc__,
                                                                      description=cls.__doc__)
         gen_file_status_report_parser.set_defaults(entry_point=GenerateStatusReportCommand)
-        gen_file_status_report_parser.add_argument('-env',
+        gen_file_status_report_parser.add_argument('--env',
                                                    help="Environment the upload area was created in (default is based "
                                                         "on currently selected upload area)",
                                                    default=None)
-        gen_file_status_report_parser.add_argument('-uuid',
+        gen_file_status_report_parser.add_argument('--uuid',
                                                    help="Full UUID of an upload area (default is based on currently "
                                                         "selected upload area)",
                                                    default=None)
-        gen_file_status_report_parser.add_argument('-output_file_name',
+        gen_file_status_report_parser.add_argument('--output_file_name',
                                                    help='Name of output file (default is upload area name)',
                                                    default=None)
 

--- a/hca/upload/cli/list_file_status_command.py
+++ b/hca/upload/cli/list_file_status_command.py
@@ -16,11 +16,11 @@ class ListFileStatusCommand(UploadCLICommand):
                                                                  description=cls.__doc__)
         list_file_statuses_parser.set_defaults(entry_point=ListFileStatusCommand)
         list_file_statuses_parser.add_argument('filename', help='File name')
-        list_file_statuses_parser.add_argument('-env',
+        list_file_statuses_parser.add_argument('--env',
                                                help="Environment the upload area was created in (default is based on "
                                                     "currently selected upload area)",
                                                default=None)
-        list_file_statuses_parser.add_argument('-uuid',
+        list_file_statuses_parser.add_argument('--uuid',
                                                help="Full UUID of an upload area (default is based on currently "
                                                     "selected upload area)",
                                                default=None)


### PR DESCRIPTION
This PR modifies several flags that start with `-` but are multiword flags, like `-env`, to start with a two dashes `--env`. It makes these flags consistent with other flags. It may break scripts that use a single dash. This affects the following CLI functions:

```
hca upload status
hca upload report
```

Addresses an item in #443