### PR TITLE
Fix import dependencies.

### DIFF
--- a/hca/config.py
+++ b/hca/config.py
@@ -2,7 +2,6 @@
 import logging
 import os
 
-import tqdm
 from tweak import Config as _Config
 
 
@@ -37,6 +36,7 @@ class ProgressBarStreamHandler(object):
     """
     @staticmethod
     def write(msg):
+        import tqdm  # imported here to avoid unnecessary dependency breaks
         tqdm.tqdm.write(msg, end='')
 
 


### PR DESCRIPTION
The CLI can't be installed via normal methods anymore since it's importing dependencies when fetching the version.  This should fix: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/54102