### PR TITLE
Fix import dependencies

### DIFF
--- a/hca/config.py
+++ b/hca/config.py
@@ -2,7 +2,6 @@
 import logging
 import os
 
-import tqdm
 from tweak import Config as _Config
 
 
@@ -37,6 +36,7 @@ class ProgressBarStreamHandler(object):
     """
     @staticmethod
     def write(msg):
+        import tqdm  # imported here to avoid unnecessary dependency breaks
         tqdm.tqdm.write(msg, end='')
 
 

--- a/hca/config.py
+++ b/hca/config.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+import tqdm
 from tweak import Config as _Config
 
 
@@ -36,7 +37,6 @@ class ProgressBarStreamHandler(object):
     """
     @staticmethod
     def write(msg):
-        import tqdm  # imported here to avoid unnecessary dependency breaks
         tqdm.tqdm.write(msg, end='')
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,12 @@
 
 import os
 from setuptools import setup, find_packages
-from hca.version import __version__
 
 install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
 
 setup(
     name="hca",
-    version=__version__,
+    version='6.6.0dev',
     url='https://github.com/HumanCellAtlas/dcp-cli',
     license='Apache Software License',
     author='Human Cell Atlas contributors',


### PR DESCRIPTION
Hard-coding this as per the old behavior.  I'll leave it to Charles if he wants to modify this in the future and attempt to adjust the cascade of dependencies that importing `__version__` requires.