### PR TITLE
Update version number to revert #476

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="hca",
-    version='6.6.0dev',
+    version='6.5.0',
     url='https://github.com/HumanCellAtlas/dcp-cli',
     license='Apache Software License',
     author='Human Cell Atlas contributors',


### PR DESCRIPTION
Reverts PR #476 to the original version number in setup.py, to conform to the format expected by the release `make` rules (see `common.mk` in top level of repo).

Also see https://github.com/HumanCellAtlas/dcp-cli/pull/476/files#diff-2eeaed663bd0d25b7e608891384b7298L10