### PR TITLE
Add `httpie` as dev requirement (#495)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 awscli
 coverage
 flake8
+httpie
 mock
 
 # Old versions of moto do not mock boto3 objects with sufficient fidelity.


### PR DESCRIPTION
The httpie library is used in the release script. On Ubuntu, the
default, snappy installed version can cause errors.