### PR TITLE
pin docutils in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ dcplib >= 2.0.2, < 3
 
 # The version range of docutils is pinned by botocore. Pinning it here can cause a version conflict.
 # See https://github.com/boto/botocore/pull/1802, https://github.com/HumanCellAtlas/dcp-cli/issues/418
-# docutils
+docutils < 0.16
 
 google-auth >= 1.3.0, < 2
 google-auth-oauthlib >= 0.4.1, < 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ dcplib >= 2.0.2, < 3
 
 # The version range of docutils is pinned by botocore. Pinning it here can cause a version conflict.
 # See https://github.com/boto/botocore/pull/1802, https://github.com/HumanCellAtlas/dcp-cli/issues/418
-docutils
+# docutils
 
 google-auth >= 1.3.0, < 2
 google-auth-oauthlib >= 0.4.1, < 2


### PR DESCRIPTION
User states that an error occurs when installing the `hca` tool with [conda](https://bioconda.github.io/recipes/hca/README.html?highlight=hca)

Due to conflicting docutils version pinned in `requirements.txt` and from within botocore, conda is unable to install the `hca` tool correctly.

Issue also observed when trying to perform a `pip install -r requirements.txt` within a clean virtual env. 