### PR TITLE
Fall back to copying when os.link raises error

### DIFF
--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -58,9 +58,10 @@ def hardlink(source, link_name):
         if source_stat.st_dev != dest_stat.st_dev or source_stat.st_ino != dest_stat.st_ino:
             raise
     except OSError as e:
-        # ELINK can occur when max number of links has been reached
-        # EPERM can occur when writing to NFS
-        copy_on_error = (errno.EMLINK, errno.EPERM)
+        copy_on_error = (
+            errno.EMLINK,  # max. number of hard links exceeded
+            errno.EPERM,  # observed on NFS mounts (issue #519)
+        )
         if e.errno in copy_on_error:
             # FIXME: Copying is not space efficient; see https://github.com/HumanCellAtlas/dcp-cli/issues/453
             log.warning('Failed to link source `%s` to destination `%s`; reverting to copying', source, link_name)

--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -58,11 +58,9 @@ def hardlink(source, link_name):
         if source_stat.st_dev != dest_stat.st_dev or source_stat.st_ino != dest_stat.st_ino:
             raise
     except OSError as e:
-        copy_on_error = [
-            errno.EMLINK,  # too many links
-            errno.EACCES,  # permission denied
-            errno.EPERM,  # operation not permitted
-        ]
+        # ELINK can occur when max number of links has been reached
+        # EPERM can occur when writing to NFS
+        copy_on_error = (errno.EMLINK, errno.EPERM)
         if e.errno in copy_on_error:
             # FIXME: Copying is not space efficient; see https://github.com/HumanCellAtlas/dcp-cli/issues/453
             log.warning('Failed to link source `%s` to destination `%s`; reverting to copying', source, link_name)

--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -58,7 +58,13 @@ def hardlink(source, link_name):
         if source_stat.st_dev != dest_stat.st_dev or source_stat.st_ino != dest_stat.st_ino:
             raise
     except OSError as e:
-        if e.errno == errno.EMLINK:
+        # See https://docs.python.org/3/library/errno.html
+        copy_on_error = [
+            errno.EMLINK,  # too many links
+            errno.EACCES,  # permission denied
+            errno.EPERM,  # operation not permitted
+        ]
+        if e.errno in copy_on_error:
             # FIXME: Copying is not space efficient; see https://github.com/HumanCellAtlas/dcp-cli/issues/453
             log.warning('Failed to link source `%s` to destination `%s`; reverting to copying', source, link_name)
             shutil.copyfile(source, link_name)

--- a/hca/dss/util/__init__.py
+++ b/hca/dss/util/__init__.py
@@ -58,7 +58,6 @@ def hardlink(source, link_name):
         if source_stat.st_dev != dest_stat.st_dev or source_stat.st_ino != dest_stat.st_ino:
             raise
     except OSError as e:
-        # See https://docs.python.org/3/library/errno.html
         copy_on_error = [
             errno.EMLINK,  # too many links
             errno.EACCES,  # permission denied


### PR DESCRIPTION
This addresses a permission denied error on NFS file systems that is caused by the `os.link` call. Addresses #519 

Previously we were catching a "too many links" exception, now we are also catching a "permission denied" exception and an "operation not permitted" exception. (Note that we may be able to remove the "operation not permitted" exception number from the list of exceptions that lead us to fall back to copying.)

### Useful Links

Useful discussion of possible approaches to solving this better: https://bugs.python.org/issue37612

Useful info about NFS and Python's os module: https://web.archive.org/web/20100912144722/http://www.unixcoding.org/NFSCoding

Note: this PR does not (yet) have tests for the new error codes being caught/handled. Tests TBA.