### PR TITLE
Remove dss-prod from testing

### DIFF
--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -26,7 +26,9 @@ class TestDssApi(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.client = hca.dss.DSSClient()
+        # Explicitly set to dss-integration rather than what the local config is set to.
+        # Ensures no bundles are uploaded to dss-prod from operators machine.
+        cls.client = hca.dss.DSSClient(swagger_url="https://dss.integration.data.humancellatlas.org/v1/swagger.json")
 
     def test_set_host(self):
         with tempfile.TemporaryDirectory() as home:

--- a/test/integration/dss/test_dss_api_retry.py
+++ b/test/integration/dss/test_dss_api_retry.py
@@ -26,6 +26,10 @@ class TestDssApiRetry(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Explicitly set to dss-integration rather than what the local config is set to.
+        # Ensures no bundles are uploaded to dss-prod from operators machine.
+        cls.client = hca.dss.DSSClient(swagger_url="https://dss.integration.data.humancellatlas.org/v1/swagger.json")
+
         with tempfile.TemporaryDirectory() as src_dir:
             bundle_path = os.path.join(src_dir, "bundle")
             os.makedirs(bundle_path)
@@ -49,7 +53,7 @@ class TestDssApiRetry(unittest.TestCase):
         Test that GET methods are retried.  We instruct the server to fake a 504 with some probability, and we should
         retry until successful.
         """
-        client = hca.dss.DSSClient()
+        client = self.client
         file_uuid = str(uuid.uuid4())
         creator_uid = client.config.get("creator_uid", 0)
         version = datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ")

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -27,20 +27,12 @@ class TestDssCLI(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        These tests rely on a logged in env, assert that the stage is not dss-prod
+        These tests rely on a logged in env, ensure that the current stage is not dss-prod
         """
-        # the dss-api endpoint 'get-bundles-all' provides the stage within the response
-        args = ["dss", "get-bundles-all", "--replica", "aws",
-                "--per-page", "10", "--no-paginate"]
-        with CapturingIO('stdout') as stdout:
-            hca.cli.main(args)
-        result = json.loads(stdout.captured())
-        try:
-            assert("https://dss.data.humancellatlas.org" not in result["dss_api"])
-        except AssertionError:
-            print('\nPlease change the DSS swagger endpoint in the HCA config file away from `dss-prod`\n'
-                  'For more information see: `https://github.com/HumanCellAtlas/dcp-cli#development`')
-            exit(1)
+        config = hca.get_config()
+        if "https://dss.data.humancellatlas.org" in config['DSSClient']['swagger_url']:
+            raise ValueError('Please change the DSS swagger endpoint in the HCA config file away from `dss-prod`\n'
+                             'For more information see: `https://github.com/HumanCellAtlas/dcp-cli#development`')
 
     def test_post_search_cli(self):
         query = json.dumps({})

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -24,6 +24,24 @@ from test import CapturingIO, reset_tweak_changes, TEST_DIR
 
 
 class TestDssCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        These tests rely on a logged in env, assert that the stage is not dss-prod
+        """
+        # the dss-api endpoint 'get-bundles-all' provides the stage within the response
+        args = ["dss", "get-bundles-all", "--replica", "aws",
+                "--per-page", "10", "--no-paginate"]
+        with CapturingIO('stdout') as stdout:
+            hca.cli.main(args)
+        result = json.loads(stdout.captured())
+        try:
+            assert("https://dss.data.humancellatlas.org" not in result["dss_api"])
+        except AssertionError:
+            print('\nPlease change the DSS swagger endpoint in the HCA config file away from `dss-prod`\n'
+                  'For more information see: `https://github.com/HumanCellAtlas/dcp-cli#development`')
+            exit(1)
+
     def test_post_search_cli(self):
         query = json.dumps({})
         replica = "aws"


### PR DESCRIPTION
Removes the potential for dss-tests to be run against `dss-prod` when on an operators machine. 

See: https://github.com/DataBiosphere/azul/issues/1768

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
